### PR TITLE
Fix for AESH-465, better clear Ctrl-L handling

### DIFF
--- a/readline/src/main/java/org/aesh/readline/action/mappings/Clear.java
+++ b/readline/src/main/java/org/aesh/readline/action/mappings/Clear.java
@@ -35,10 +35,7 @@ public class Clear implements Action {
     @Override
     public void accept(InputProcessor inputProcessor) {
         inputProcessor.buffer().writeOut(ANSI.CLEAR_SCREEN);
-        //move cursor to correct position
-        inputProcessor.buffer().writeChars(ANSI.printAnsi("1;1H"));
-        //then write prompt
-        inputProcessor.buffer().buffer().reset();
-        inputProcessor.buffer().undoManager().clear();
+        //move cursor to correct position and redraw prompt.
+        inputProcessor.buffer().replace(ANSI.printAnsi("1;1H"));
     }
 }


### PR DESCRIPTION
Fix for clear action. Currently the clear action attempts to:
1) Clear the screen fully.
2) Move the cursor to 1:1 
3) Re-display the prompt (not working).

This PR uses replace instead of insert. Insert is not supported for Ctrl chars. Prompt is properly redrawn and screen cleared. To me that is a good enough behaviour for this case.

