### PR TITLE
Fix for AESH-499, fix cursor at the terminal edge on Mac.

### DIFF
--- a/terminal-api/src/main/java/org/aesh/utils/Config.java
+++ b/terminal-api/src/main/java/org/aesh/utils/Config.java
@@ -25,6 +25,8 @@ package org.aesh.utils;
  */
 public class Config {
 
+    private static final boolean macOS = System.getProperty("os.name").startsWith("Mac") ||
+            System.getProperty("os.name").startsWith("darwin");
     private static final boolean windows = System.getProperty("os.name").startsWith("Windows");
     private static final String lineSeparator = System.getProperty("line.separator");
     private static final String pathSeparator = System.getProperty("file.separator");
@@ -39,6 +41,10 @@ public class Config {
 
     public static boolean isCygwin() {
         return cygwin;
+    }
+
+    public static boolean isMacOS() {
+        return macOS;
     }
 
     public static boolean isWindows() {


### PR DESCRIPTION
1) When reaching the edge and the cursor is not at the end of the command, the cursor on mac will be located on the newly added line (pad line), index 0. So we must move up to the line where the cursor is located, then move forward to its current pos. This fixes the original issue.

2) When deleting char and the command reaches the edge of the terminal, we must move the cursor 1 more char to have it in sync with its new position. New problem found.

These 2 issues are Mac OSX specific.