### PR TITLE
Fix for AESH-505, [SmartOS] Not present tty attribute breaks the terminal

### DIFF
--- a/readline/src/main/java/org/aesh/readline/terminal/impl/ExecPty.java
+++ b/readline/src/main/java/org/aesh/readline/terminal/impl/ExecPty.java
@@ -174,14 +174,13 @@ public class ExecPty implements Pty {
         }
         String undef = System.getProperty("os.name").toLowerCase().startsWith("hp") ? "^-" : "undef";
         for (Attributes.ControlChar cchar : Attributes.ControlChar.values()) {
-            if (attr.getControlChar(cchar) != current.getControlChar(cchar)) {
+            int v = attr.getControlChar(cchar);
+            if (v >= 0 && v != current.getControlChar(cchar)) {
                 String str = "";
-                int v = attr.getControlChar(cchar);
                 commands.add(cchar.name().toLowerCase().substring(1));
                 if (cchar == Attributes.ControlChar.VMIN || cchar == Attributes.ControlChar.VTIME) {
-                    commands.add(Integer.toBinaryString(v));
-                }
-                else if (v == 0) {
+                    commands.add(Integer.toString(v));
+                } else if (v == 0) {
                     commands.add(undef);
                 }
                 else {


### PR DESCRIPTION
This fix has been inspired by the fix done for this JLine issue https://github.com/jline/jline3/issues/330
Actually there is 2 fixes:
* Ignore default value (-1).
* Do not use toBinaryString that seems wrong.