### PR TITLE
Configure behavior of when to activate multi line mode and handling comments

### DIFF
--- a/readline/src/main/java/org/aesh/readline/ReadlineFlag.java
+++ b/readline/src/main/java/org/aesh/readline/ReadlineFlag.java
@@ -31,6 +31,11 @@ public enum ReadlineFlag {
      * <li>2 = Disable for single quote
      * </ul>
      */
-    NO_MULTI_LINE_ON_QUOTE
+    NO_MULTI_LINE_ON_QUOTE,
+
+    /**
+     * Do not discard lines starting with '#'
+     */
+    NO_COMMENT_DISCARD
 
 }

--- a/readline/src/main/java/org/aesh/readline/ReadlineFlag.java
+++ b/readline/src/main/java/org/aesh/readline/ReadlineFlag.java
@@ -21,6 +21,16 @@ public enum ReadlineFlag {
     /**
      * Ignore EOF signal a given number of times
      */
-    IGNORE_EOF
+    IGNORE_EOF,
+
+    /**
+     * Do not activate multi-line mode
+     * <ul>
+     * <li>0 = Disable for both single and double quote
+     * <li>1 = Disable for double quote
+     * <li>2 = Disable for single quote
+     * </ul>
+     */
+    NO_MULTI_LINE_ON_QUOTE
 
 }

--- a/readline/src/main/java/org/aesh/readline/action/mappings/Enter.java
+++ b/readline/src/main/java/org/aesh/readline/action/mappings/Enter.java
@@ -48,12 +48,15 @@ public class Enter implements Action {
         // (0=ignore both, 1=ignore for double quotes, 2=ignore for single quotes)
         int multilineFlags = inputProcessor.flags().getOrDefault(ReadlineFlag.NO_MULTI_LINE_ON_QUOTE, -1);
         boolean ignoreQuotes = multilineFlags == 0;
+        // check flags to see if we should discard lines starting with a '#'
+        int commentFlag = inputProcessor.flags().getOrDefault(ReadlineFlag.NO_COMMENT_DISCARD, -1);
+        boolean discardComments = commentFlag == -1;
 
         if(!consoleBuffer.buffer().isMasking()) { // don't push to history if masking
             // don't push lines that end with \ to history
             String buffer = consoleBuffer.buffer().asString().trim();
             // lines starting with a hashtag is treated as a comment
-            if(buffer.startsWith(HASHTAG) ) {
+            if(discardComments && buffer.startsWith(HASHTAG)) {
                 consoleBuffer.buffer().reset();
                 inputProcessor.buffer().writeOut(Config.CR);
                 isCurrentLineEnding = false;

--- a/readline/src/main/java/org/aesh/readline/util/Parser.java
+++ b/readline/src/main/java/org/aesh/readline/util/Parser.java
@@ -535,12 +535,16 @@ public class Parser {
     }
 
     /**
-     * Check if a string contain openBlocking quotes. Escaped quotes does not count.
+     * Check if a string contain open quotes. Escaped quotes does not count.
      *
      * @param text text
-     * @return true if it contains openBlocking quotes, else false
+     * @param flags flags, <code>1</code> to ignore double quotes, <code>2</code> to ignore single
+     * quotes. Other values will check for both.
+     * @return true if it contains open quotes, else false
      */
-    public static boolean doesStringContainOpenQuote(String text) {
+    public static boolean doesStringContainOpenQuote(String text, int flags) {
+        boolean ignoreDoubleQuote = flags == 1;
+        boolean ignoreSingleQuote = flags == 2;
         boolean doubleQuote = false;
         boolean singleQuote = false;
         boolean escapedByBackSlash = false;
@@ -553,16 +557,20 @@ public class Parser {
                  escapedByBackSlash = !escapedByBackSlash;
                  continue;
              }
-            if (text.charAt(i) == SINGLE_QUOTE) {
+            if (text.charAt(i) == SINGLE_QUOTE && !ignoreSingleQuote) {
                 if (!doubleQuote)
                     singleQuote = !singleQuote;
             }
-            else if (text.charAt(i) == DOUBLE_QUOTE) {
+            else if (text.charAt(i) == DOUBLE_QUOTE && !ignoreDoubleQuote) {
                 if (!singleQuote)
                     doubleQuote = !doubleQuote;
             }
         }
         return doubleQuote || singleQuote;
+    }
+
+    public static boolean doesStringContainOpenQuote(String text) {
+        return doesStringContainOpenQuote(text, -1);
     }
 
     public static boolean doWordContainOnlyEscapedSpace(String word) {

--- a/readline/src/test/java/org/aesh/parser/ParserTest.java
+++ b/readline/src/test/java/org/aesh/parser/ParserTest.java
@@ -191,6 +191,27 @@ public class ParserTest {
         assertTrue(Parser.doesStringContainOpenQuote("\"foo bar is bar is \\\"foo is bar\'"));
     }
 
+    @Test
+    public void testDoesStringContainQuoteIgnoreSingleQuote() {
+        int flags = 2; // ignore single quotes
+        assertFalse(Parser.doesStringContainOpenQuote("foo bar is bar", flags));
+        assertFalse(Parser.doesStringContainOpenQuote("\'foo bar \"is bar is \"foo is bar\'", flags));
+        assertFalse(Parser.doesStringContainOpenQuote("\'foo bar is bar is foo is bar", flags));
+        assertFalse(Parser.doesStringContainOpenQuote("'foo bar is bar is foo is bar", flags));
+        assertTrue(Parser.doesStringContainOpenQuote("'foo bar is bar is foo is bar"));
+        assertFalse(Parser.doesStringContainOpenQuote("'", flags));
+        assertTrue(Parser.doesStringContainOpenQuote("\"", flags));
+    }
+
+    @Test
+    public void testDoesStringContainQuoteIgnoreDoubleQuote() {
+        int flags = 1; // ignore double quotes
+        assertFalse(Parser.doesStringContainOpenQuote("foo bar is bar", flags));
+        assertTrue(Parser.doesStringContainOpenQuote("'", flags));
+        assertFalse(Parser.doesStringContainOpenQuote("''", flags));
+        assertFalse(Parser.doesStringContainOpenQuote("\\'", flags));
+        assertFalse(Parser.doesStringContainOpenQuote("\"", flags));
+    }
 
     @Test
     public void testFormatDisplayCompactListTerminalString() {

--- a/readline/src/test/java/org/aesh/readline/ReadlineTest.java
+++ b/readline/src/test/java/org/aesh/readline/ReadlineTest.java
@@ -346,4 +346,21 @@ public class ReadlineTest {
         term.assertLine("\"foo ");
     }
 
+    @Test
+    public void testNoDiscardOfComment() {
+        EnumMap<ReadlineFlag, Integer> flags = new EnumMap<>(ReadlineFlag.class);
+        TestConnection term;
+        term = new TestConnection(); // default behavior, discard comment
+        term.read("# this is a comment");
+        term.clearOutputBuffer();
+        term.read(Key.ENTER);
+        term.assertLine(null);
+        flags.put(ReadlineFlag.NO_COMMENT_DISCARD, 1);
+        term = new TestConnection(flags); // do not discard comment
+        term.read("# this is not a comment");
+        term.clearOutputBuffer();
+        term.read(Key.ENTER);
+        term.assertLine("# this is not a comment");
+    }
+
 }

--- a/readline/src/test/java/org/aesh/readline/ReadlineTest.java
+++ b/readline/src/test/java/org/aesh/readline/ReadlineTest.java
@@ -19,6 +19,7 @@
  */
 package org.aesh.readline;
 
+import java.util.EnumMap;
 import org.aesh.readline.completion.Completion;
 import org.aesh.readline.cursor.Line;
 import org.aesh.readline.editing.EditModeBuilder;
@@ -322,4 +323,27 @@ public class ReadlineTest {
         s = line.getLineToCursor();
         assertEquals(": 12", s);
     }
+
+    @Test
+    public void testMultiLineDisableForSingleQuote() {
+        EnumMap<ReadlineFlag, Integer> flags = new EnumMap<>(ReadlineFlag.class);
+        flags.put(ReadlineFlag.NO_MULTI_LINE_ON_QUOTE, 2);
+        TestConnection term = new TestConnection(flags);
+        term.read("'foo ");
+        term.clearOutputBuffer();
+        term.read(Key.ENTER);
+        term.assertLine("'foo ");
+    }
+
+    @Test
+    public void testMultiLineDisableForDoubleQuote() {
+        EnumMap<ReadlineFlag, Integer> flags = new EnumMap<>(ReadlineFlag.class);
+        flags.put(ReadlineFlag.NO_MULTI_LINE_ON_QUOTE, 1);
+        TestConnection term = new TestConnection(flags);
+        term.read("\"foo ");
+        term.clearOutputBuffer();
+        term.read(Key.ENTER);
+        term.assertLine("\"foo ");
+    }
+
 }


### PR DESCRIPTION
I have a use case where I want to be able to input a single (open) quote in a line using `aesh-readline` without activating the multi line mode. I also want to be able to read a line starting with `#`.

This PR contains changes that adds fields to the ReadLineFlags enum that will be regarded in the `accept-line` action, providing the possibility to configure if quotes (both single, double or both) should activate multi line mode, as well as if a comment should be discarded or not.
