### PR TITLE
Add grapheme cluster support and update emoji widths fixes #100

### DIFF
--- a/terminal-api/src/main/java/org/aesh/terminal/Connection.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/Connection.java
@@ -288,8 +288,8 @@ public interface Connection extends AutoCloseable {
      * Send a query to the terminal and wait for a response with timeout.
      * <p>
      * This method enters raw mode, sends the query, collects the response,
-     * and restores the original terminal attributes. It's useful for OSC queries
-     * and other terminal interrogation sequences.
+     * and restores the original terminal attributes. It's useful for both
+     * OSC queries and CSI queries (DA1/DA2, DECRQM, theme DSR, etc.).
      * <p>
      * This method uses {@link #setStdinHandler(Consumer)} to receive responses,
      * which requires the connection to be actively reading input (i.e.,
@@ -313,11 +313,6 @@ public interface Connection extends AutoCloseable {
 
         // This method uses setStdinHandler which requires active reading
         if (!reading()) {
-            return null;
-        }
-
-        // Check if OSC queries are supported
-        if (device() != null && !device().supportsOscQueries()) {
             return null;
         }
 
@@ -468,6 +463,10 @@ public interface Connection extends AutoCloseable {
      */
     default <T> T queryOsc(int oscCode, String param, long timeoutMs,
             java.util.function.Function<int[], T> responseParser) {
+        // OSC queries require OSC support from the terminal
+        if (device() != null && !device().supportsOscQueries()) {
+            return null;
+        }
         String query = ANSI.buildOscQuery(oscCode, param);
         return queryTerminal(query, timeoutMs, responseParser);
     }
@@ -671,6 +670,10 @@ public interface Connection extends AutoCloseable {
      */
     default <T> T queryOsc(int oscCode, int index, String param, long timeoutMs,
             java.util.function.Function<int[], T> responseParser) {
+        // OSC queries require OSC support from the terminal
+        if (device() != null && !device().supportsOscQueries()) {
+            return null;
+        }
         String query = ANSI.buildOscQuery(oscCode, index, param);
         return queryTerminal(query, timeoutMs, responseParser);
     }
@@ -936,6 +939,62 @@ public interface Connection extends AutoCloseable {
         DeviceAttributes attrs = queryPrimaryDeviceAttributes(timeoutMs);
         String termType = device() != null ? device().type() : null;
         return ImageProtocolDetector.detect(attrs, termType);
+    }
+
+    // ==================== Mode 2027 (Grapheme Cluster Mode) ====================
+
+    /**
+     * Check if Mode 2027 (grapheme cluster segmentation) is likely supported.
+     * <p>
+     * This delegates to the device's capability detection based on terminal type.
+     * Returns false for dumb terminals or when the device is null.
+     *
+     * @return true if Mode 2027 is likely supported
+     */
+    default boolean supportsGraphemeClusterMode() {
+        if (device() == null || !supportsAnsi()) {
+            return false;
+        }
+        return device().supportsGraphemeClusterMode();
+    }
+
+    /**
+     * Query the terminal to check if Mode 2027 is supported via DECRQM.
+     * <p>
+     * This sends a DECRQM (DEC Private Mode Request Mode) query for Mode 2027
+     * and parses the DECRPM response.
+     * <p>
+     * The terminal must be actively reading input for this to work.
+     *
+     * @param timeoutMs timeout in milliseconds to wait for response
+     * @return true if supported, false if not supported, null if no response/timeout
+     */
+    default Boolean queryGraphemeClusterMode(long timeoutMs) {
+        return queryTerminal(ANSI.MODE_2027_QUERY, timeoutMs, ANSI::parseMode2027Response);
+    }
+
+    /**
+     * Enable Mode 2027 (grapheme cluster segmentation).
+     * <p>
+     * When enabled, the terminal uses UAX #29 grapheme cluster segmentation
+     * for cursor positioning instead of per-codepoint wcwidth.
+     *
+     * @return this connection
+     */
+    default Connection enableGraphemeClusterMode() {
+        return write(ANSI.MODE_2027_ENABLE);
+    }
+
+    /**
+     * Disable Mode 2027 (grapheme cluster segmentation).
+     * <p>
+     * When disabled, the terminal reverts to per-codepoint wcwidth for
+     * cursor positioning.
+     *
+     * @return this connection
+     */
+    default Connection disableGraphemeClusterMode() {
+        return write(ANSI.MODE_2027_DISABLE);
     }
 
     // ==================== OSC Support Detection ====================

--- a/terminal-api/src/main/java/org/aesh/terminal/Device.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/Device.java
@@ -77,117 +77,121 @@ public interface Device {
         // ==================== IDE Terminals ====================
 
         /** JetBrains IDEs (IntelliJ, etc.) using JediTerm */
-        JETBRAINS("JetBrains-JediTerm", EnumSet.of(OscCode.FOREGROUND, OscCode.BACKGROUND), ColorDepth.TRUE_COLOR, false),
+        JETBRAINS("JetBrains-JediTerm", EnumSet.of(OscCode.FOREGROUND, OscCode.BACKGROUND), ColorDepth.TRUE_COLOR, false,
+                false),
 
         /** Visual Studio Code integrated terminal */
         VSCODE("vscode", EnumSet.of(OscCode.FOREGROUND, OscCode.BACKGROUND, OscCode.CURSOR_COLOR, OscCode.CLIPBOARD),
-                ColorDepth.TRUE_COLOR, false),
+                ColorDepth.TRUE_COLOR, false, false),
 
         // ==================== macOS Terminals ====================
 
         /** Apple Terminal */
         APPLE_TERMINAL("Apple_Terminal", EnumSet.of(OscCode.FOREGROUND, OscCode.BACKGROUND, OscCode.CURSOR_COLOR),
-                ColorDepth.COLORS_256, false),
+                ColorDepth.COLORS_256, false, false),
 
         /** iTerm2 */
-        ITERM2("iTerm.app", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false),
+        ITERM2("iTerm.app", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false, false),
 
         // ==================== Cross-Platform Modern Terminals ====================
 
         /** Kitty terminal - GPU-accelerated, uses Kitty graphics protocol. Supports CSI ? 996 n since 0.38.1. */
-        KITTY("kitty", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, true),
+        KITTY("kitty", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, true, true),
 
         /** Ghostty - Fast GPU-accelerated terminal, uses Kitty graphics protocol. Supports CSI ? 996 n since 1.0.0. */
-        GHOSTTY("ghostty", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, true),
+        GHOSTTY("ghostty", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, true, true),
 
         /** Alacritty - GPU-accelerated terminal */
         ALACRITTY("alacritty", EnumSet.of(OscCode.FOREGROUND, OscCode.BACKGROUND, OscCode.CURSOR_COLOR), ColorDepth.TRUE_COLOR,
-                false),
+                false, false),
 
         /** WezTerm - GPU-accelerated terminal with multiplexing */
-        WEZTERM("WezTerm", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false),
+        WEZTERM("WezTerm", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false, true),
 
         /** Foot - Fast, lightweight Wayland terminal (VTE-based, supports CSI ? 996 n) */
-        FOOT("foot", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, true),
+        FOOT("foot", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, true, true),
 
         /** Contour - Modern terminal emulator. Origin of the CSI ? 996 n extension since 0.4.0. */
-        CONTOUR("contour", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, true),
+        CONTOUR("contour", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, true, true),
 
         /** Rio - Hardware-accelerated GPU terminal */
-        RIO("rio", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false),
+        RIO("rio", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false, false),
 
         /** Warp - Modern terminal with AI features */
-        WARP("warp", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false),
+        WARP("warp", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false, false),
 
         /** Wave - Modern terminal */
-        WAVE("wave", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false),
+        WAVE("wave", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false, false),
 
         // ==================== Electron-Based Terminals ====================
 
         /** Hyper - Electron-based terminal */
-        HYPER("hyper", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false),
+        HYPER("hyper", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false, false),
 
         /** Terminus/Tabby - Electron-based terminal */
-        TABBY("tabby", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false),
+        TABBY("tabby", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false, false),
 
         /** Extraterm - Electron-based terminal */
-        EXTRATERM("extraterm", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false),
+        EXTRATERM("extraterm", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false, false),
 
         // ==================== Linux Desktop Terminals ====================
 
         /** GNOME Terminal and other VTE-based terminals. Supports CSI ? 996 n since VTE 0.82.0. */
-        GNOME_TERMINAL("gnome-terminal", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, true),
+        GNOME_TERMINAL("gnome-terminal", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, true, false),
 
         /** Konsole - KDE terminal emulator */
-        KONSOLE("konsole", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false),
+        KONSOLE("konsole", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false, false),
 
         /** rxvt and urxvt */
-        RXVT("rxvt", EnumSet.of(OscCode.FOREGROUND, OscCode.BACKGROUND, OscCode.CURSOR_COLOR), ColorDepth.COLORS_256, false),
+        RXVT("rxvt", EnumSet.of(OscCode.FOREGROUND, OscCode.BACKGROUND, OscCode.CURSOR_COLOR), ColorDepth.COLORS_256, false,
+                false),
 
         // ==================== Windows Terminals ====================
 
         /** Windows Terminal */
         WINDOWS_TERMINAL("Windows Terminal", EnumSet.of(OscCode.FOREGROUND, OscCode.BACKGROUND, OscCode.CURSOR_COLOR),
-                ColorDepth.TRUE_COLOR, false),
+                ColorDepth.TRUE_COLOR, false, false),
 
         /** Mintty - Default terminal for Git Bash, Cygwin, MSYS2 */
-        MINTTY("mintty", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false),
+        MINTTY("mintty", EnumSet.allOf(OscCode.class), ColorDepth.TRUE_COLOR, false, false),
 
         /** ConEmu/Cmder - Windows console emulator */
-        CONEMU("ConEmu", EnumSet.of(OscCode.FOREGROUND, OscCode.BACKGROUND), ColorDepth.TRUE_COLOR, false),
+        CONEMU("ConEmu", EnumSet.of(OscCode.FOREGROUND, OscCode.BACKGROUND), ColorDepth.TRUE_COLOR, false, false),
 
         // ==================== Terminal Multiplexers ====================
 
         /** tmux - Terminal multiplexer. Supports CSI ? 996 n passthrough. */
-        TMUX("tmux", EnumSet.noneOf(OscCode.class), ColorDepth.COLORS_256, true),
+        TMUX("tmux", EnumSet.noneOf(OscCode.class), ColorDepth.COLORS_256, true, false),
 
         /** GNU Screen - Terminal multiplexer (no OSC passthrough by default) */
-        SCREEN("screen", EnumSet.noneOf(OscCode.class), ColorDepth.COLORS_256, false),
+        SCREEN("screen", EnumSet.noneOf(OscCode.class), ColorDepth.COLORS_256, false, false),
 
         // ==================== Classic/Legacy Terminals ====================
 
         /** xterm and compatible */
-        XTERM("xterm", EnumSet.allOf(OscCode.class), ColorDepth.COLORS_256, false),
+        XTERM("xterm", EnumSet.allOf(OscCode.class), ColorDepth.COLORS_256, false, false),
 
         /** Linux console (no OSC query support) */
-        LINUX_CONSOLE("linux", EnumSet.noneOf(OscCode.class), ColorDepth.COLORS_8, false),
+        LINUX_CONSOLE("linux", EnumSet.noneOf(OscCode.class), ColorDepth.COLORS_8, false, false),
 
         // ==================== Fallback ====================
 
         /** Unknown terminal - assume basic support */
-        UNKNOWN("unknown", EnumSet.of(OscCode.FOREGROUND, OscCode.BACKGROUND), ColorDepth.COLORS_256, false);
+        UNKNOWN("unknown", EnumSet.of(OscCode.FOREGROUND, OscCode.BACKGROUND), ColorDepth.COLORS_256, false, false);
 
         private final String identifier;
         private final Set<OscCode> supportedCodes;
         private final ColorDepth defaultColorDepth;
         private final boolean supportsThemeDsr;
+        private final boolean supportsGraphemeClusterMode;
 
         TerminalType(String identifier, Set<OscCode> supportedCodes, ColorDepth defaultColorDepth,
-                boolean supportsThemeDsr) {
+                boolean supportsThemeDsr, boolean supportsGraphemeClusterMode) {
             this.identifier = identifier;
             this.supportedCodes = Collections.unmodifiableSet(supportedCodes);
             this.defaultColorDepth = defaultColorDepth;
             this.supportsThemeDsr = supportsThemeDsr;
+            this.supportsGraphemeClusterMode = supportsGraphemeClusterMode;
         }
 
         public String getIdentifier() {
@@ -240,6 +244,22 @@ public interface Device {
          */
         public boolean supportsThemeDsr() {
             return supportsThemeDsr;
+        }
+
+        /**
+         * Check if this terminal supports Mode 2027 (grapheme cluster segmentation).
+         * <p>
+         * Mode 2027 tells the terminal to use UAX #29 grapheme cluster segmentation
+         * instead of per-codepoint wcwidth for cursor positioning. This is needed for
+         * correct handling of multi-codepoint characters like ZWJ emoji sequences,
+         * flag emoji, and combining characters.
+         * <p>
+         * Known supporting terminals: Ghostty, WezTerm, Kitty, Contour, Foot.
+         *
+         * @return true if Mode 2027 is expected to be supported
+         */
+        public boolean supportsGraphemeClusterMode() {
+            return supportsGraphemeClusterMode;
         }
 
         /**
@@ -401,6 +421,22 @@ public interface Device {
      */
     default boolean supportsOscQueries() {
         return org.aesh.terminal.utils.TerminalEnvironment.getInstance().supportsOscQueries();
+    }
+
+    /**
+     * Check if this device supports Mode 2027 (grapheme cluster segmentation).
+     * <p>
+     * Mode 2027 tells the terminal to use UAX #29 grapheme cluster segmentation
+     * instead of per-codepoint wcwidth for cursor positioning.
+     * <p>
+     * This method uses {@link org.aesh.terminal.utils.TerminalEnvironment} for
+     * environment-based detection.
+     *
+     * @return true if Mode 2027 is likely supported
+     */
+    default boolean supportsGraphemeClusterMode() {
+        return org.aesh.terminal.utils.TerminalEnvironment.getInstance()
+                .supportsGraphemeClusterMode();
     }
 
     /**

--- a/terminal-api/src/main/java/org/aesh/terminal/utils/ANSI.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/utils/ANSI.java
@@ -1122,6 +1122,87 @@ public class ANSI {
         }
     }
 
+    // ==================== Mode 2027 (Grapheme Cluster Mode) ====================
+
+    /** DECRQM query for Mode 2027 (grapheme cluster segmentation). */
+    public static final String MODE_2027_QUERY = "\u001B[?2027$p";
+
+    /** Enable Mode 2027 (grapheme cluster segmentation). */
+    public static final String MODE_2027_ENABLE = "\u001B[?2027h";
+
+    /** Disable Mode 2027 (grapheme cluster segmentation). */
+    public static final String MODE_2027_DISABLE = "\u001B[?2027l";
+
+    /**
+     * Parse a DECRPM (DEC Private Mode Report) response for Mode 2027.
+     * <p>
+     * Expected format: CSI ? 2027 ; Ps $ y
+     * <p>
+     * Where Ps indicates the mode status:
+     * <ul>
+     * <li>0 - not recognized</li>
+     * <li>1 - set (enabled)</li>
+     * <li>2 - reset (disabled, but recognized)</li>
+     * <li>3 - permanently set</li>
+     * <li>4 - permanently reset</li>
+     * </ul>
+     * <p>
+     * Returns {@code Boolean.TRUE} if Ps is 1, 2, or 3 (terminal recognizes the mode),
+     * {@code Boolean.FALSE} if Ps is 0 or 4 (not recognized or permanently disabled),
+     * or {@code null} if the response cannot be parsed.
+     *
+     * @param input the input sequence as code points
+     * @return true if the terminal supports Mode 2027, false if not, null if unparseable
+     */
+    public static Boolean parseMode2027Response(int[] input) {
+        if (input == null || input.length < 9) {
+            return null;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int c : input) {
+            sb.appendCodePoint(c);
+        }
+        String response = sb.toString();
+
+        // Look for DECRPM pattern: ESC [ ? 2027 ; Ps $ y
+        int start = response.indexOf("\u001B[?2027;");
+        if (start < 0) {
+            return null;
+        }
+
+        // Move past "ESC[?2027;" — 8 chars: \u001B [ ? 2 0 2 7 ;
+        int paramStart = start + "\u001B[?2027;".length();
+
+        // Find the terminating "$y"
+        int end = response.indexOf("$y", paramStart);
+        if (end < 0) {
+            return null;
+        }
+
+        String paramStr = response.substring(paramStart, end).trim();
+        if (paramStr.isEmpty()) {
+            return null;
+        }
+
+        try {
+            int ps = Integer.parseInt(paramStr);
+            switch (ps) {
+                case 1: // set (enabled)
+                case 2: // reset (disabled, but recognized)
+                case 3: // permanently set
+                    return Boolean.TRUE;
+                case 0: // not recognized
+                case 4: // permanently reset
+                    return Boolean.FALSE;
+                default:
+                    return null;
+            }
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
     // ==================== Device Attributes (DA1/DA2) ====================
 
     /** DA1 (Primary Device Attributes) query sequence. */

--- a/terminal-api/src/main/java/org/aesh/terminal/utils/TerminalEnvironment.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/utils/TerminalEnvironment.java
@@ -378,6 +378,17 @@ public final class TerminalEnvironment {
     }
 
     /**
+     * Check if Mode 2027 (grapheme cluster segmentation) is likely supported.
+     * <p>
+     * This delegates to the detected terminal type's grapheme cluster mode support.
+     *
+     * @return true if Mode 2027 is likely supported
+     */
+    public boolean supportsGraphemeClusterMode() {
+        return terminalType.supportsGraphemeClusterMode();
+    }
+
+    /**
      * Check if a known OSC-capable outer terminal is detected.
      * <p>
      * This is useful for nested terminal sessions (e.g., tmux inside Kitty).

--- a/terminal-api/src/main/java/org/aesh/terminal/utils/WcWidth.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/utils/WcWidth.java
@@ -204,6 +204,15 @@ public final class WcWidth {
                                 (ucs >= 0xfe30 && ucs <= 0xfe6f) || /* CJK Compatibility Forms */
                                 (ucs >= 0xff00 && ucs <= 0xff60) || /* Fullwidth Forms */
                                 (ucs >= 0xffe0 && ucs <= 0xffe6) ||
+                                (ucs >= 0x1f300 && ucs <= 0x1f5ff) || /* Misc Symbols and Pictographs */
+                                (ucs >= 0x1f600 && ucs <= 0x1f64f) || /* Emoticons */
+                                (ucs >= 0x1f680 && ucs <= 0x1f6ff) || /* Transport and Map */
+                                (ucs >= 0x1f7e0 && ucs <= 0x1f7eb) || /*
+                                                                       * Geometric Shapes Extended (colored emoji
+                                                                       * circles/squares)
+                                                                       */
+                                (ucs >= 0x1f900 && ucs <= 0x1f9ff) || /* Supplemental Symbols and Pictographs */
+                                (ucs >= 0x1fa70 && ucs <= 0x1faff) || /* Symbols and Pictographs Extended-A */
                                 (ucs >= 0x20000 && ucs <= 0x2fffd) ||
                                 (ucs >= 0x30000 && ucs <= 0x3fffd))) ? 1 : 0);
     }

--- a/terminal-api/src/test/java/org/aesh/terminal/GraphemeClusterModeTest.java
+++ b/terminal-api/src/test/java/org/aesh/terminal/GraphemeClusterModeTest.java
@@ -1,0 +1,399 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aesh.terminal;
+
+import static org.junit.Assert.*;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import org.aesh.terminal.tty.Capability;
+import org.aesh.terminal.tty.Signal;
+import org.aesh.terminal.tty.Size;
+import org.junit.Test;
+
+/**
+ * Tests for Mode 2027 (grapheme cluster mode) support across
+ * TerminalType, Device, and Connection.
+ *
+ * @author Ståle Pedersen
+ */
+public class GraphemeClusterModeTest {
+
+    // ==================== TerminalType Tests ====================
+
+    @Test
+    public void testGhosttySupportsGraphemeClusterMode() {
+        assertTrue("Ghostty should support Mode 2027",
+                Device.TerminalType.GHOSTTY.supportsGraphemeClusterMode());
+    }
+
+    @Test
+    public void testWeztermSupportsGraphemeClusterMode() {
+        assertTrue("WezTerm should support Mode 2027",
+                Device.TerminalType.WEZTERM.supportsGraphemeClusterMode());
+    }
+
+    @Test
+    public void testKittySupportsGraphemeClusterMode() {
+        assertTrue("Kitty should support Mode 2027",
+                Device.TerminalType.KITTY.supportsGraphemeClusterMode());
+    }
+
+    @Test
+    public void testContourSupportsGraphemeClusterMode() {
+        assertTrue("Contour should support Mode 2027",
+                Device.TerminalType.CONTOUR.supportsGraphemeClusterMode());
+    }
+
+    @Test
+    public void testFootSupportsGraphemeClusterMode() {
+        assertTrue("Foot should support Mode 2027",
+                Device.TerminalType.FOOT.supportsGraphemeClusterMode());
+    }
+
+    @Test
+    public void testXtermDoesNotSupportGraphemeClusterMode() {
+        assertFalse("xterm should not support Mode 2027",
+                Device.TerminalType.XTERM.supportsGraphemeClusterMode());
+    }
+
+    @Test
+    public void testLinuxConsoleDoesNotSupportGraphemeClusterMode() {
+        assertFalse("Linux console should not support Mode 2027",
+                Device.TerminalType.LINUX_CONSOLE.supportsGraphemeClusterMode());
+    }
+
+    @Test
+    public void testTmuxDoesNotSupportGraphemeClusterMode() {
+        assertFalse("tmux should not support Mode 2027",
+                Device.TerminalType.TMUX.supportsGraphemeClusterMode());
+    }
+
+    @Test
+    public void testScreenDoesNotSupportGraphemeClusterMode() {
+        assertFalse("GNU Screen should not support Mode 2027",
+                Device.TerminalType.SCREEN.supportsGraphemeClusterMode());
+    }
+
+    @Test
+    public void testUnknownDoesNotSupportGraphemeClusterMode() {
+        assertFalse("Unknown terminal should not support Mode 2027",
+                Device.TerminalType.UNKNOWN.supportsGraphemeClusterMode());
+    }
+
+    @Test
+    public void testVscodeDoesNotSupportGraphemeClusterMode() {
+        assertFalse("VSCode should not support Mode 2027",
+                Device.TerminalType.VSCODE.supportsGraphemeClusterMode());
+    }
+
+    @Test
+    public void testJetbrainsDoesNotSupportGraphemeClusterMode() {
+        assertFalse("JetBrains should not support Mode 2027",
+                Device.TerminalType.JETBRAINS.supportsGraphemeClusterMode());
+    }
+
+    @Test
+    public void testAlacrittyDoesNotSupportGraphemeClusterMode() {
+        assertFalse("Alacritty should not support Mode 2027",
+                Device.TerminalType.ALACRITTY.supportsGraphemeClusterMode());
+    }
+
+    @Test
+    public void testIterm2DoesNotSupportGraphemeClusterMode() {
+        assertFalse("iTerm2 should not support Mode 2027",
+                Device.TerminalType.ITERM2.supportsGraphemeClusterMode());
+    }
+
+    // ==================== Connection Query Tests ====================
+
+    @Test
+    public void testQueryGraphemeClusterMode_Supported() throws Exception {
+        MockConnection connection = new MockConnection();
+
+        CountDownLatch queryStarted = new CountDownLatch(1);
+        Thread responseThread = new Thread(() -> {
+            try {
+                queryStarted.await(1, TimeUnit.SECONDS);
+                Thread.sleep(20);
+                // Terminal responds: Mode 2027 is reset (recognized but disabled)
+                String response = "\u001B[?2027;2$y";
+                connection.simulateInput(response);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        responseThread.start();
+
+        queryStarted.countDown();
+        Boolean result = connection.queryGraphemeClusterMode(500);
+        responseThread.join(1000);
+
+        assertNotNull("Should get a response from terminal", result);
+        assertTrue("Ps=2 means terminal recognizes Mode 2027", result);
+    }
+
+    @Test
+    public void testQueryGraphemeClusterMode_NotSupported() throws Exception {
+        MockConnection connection = new MockConnection();
+
+        CountDownLatch queryStarted = new CountDownLatch(1);
+        Thread responseThread = new Thread(() -> {
+            try {
+                queryStarted.await(1, TimeUnit.SECONDS);
+                Thread.sleep(20);
+                // Terminal responds: Mode 2027 is not recognized
+                String response = "\u001B[?2027;0$y";
+                connection.simulateInput(response);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        responseThread.start();
+
+        queryStarted.countDown();
+        Boolean result = connection.queryGraphemeClusterMode(500);
+        responseThread.join(1000);
+
+        assertNotNull("Should get a response from terminal", result);
+        assertFalse("Ps=0 means terminal does not recognize Mode 2027", result);
+    }
+
+    @Test
+    public void testQueryGraphemeClusterMode_Timeout() {
+        MockConnection connection = new MockConnection();
+
+        // No response simulated - should timeout
+        Boolean result = connection.queryGraphemeClusterMode(100);
+
+        assertNull("Should return null on timeout", result);
+    }
+
+    @Test
+    public void testEnableGraphemeClusterMode_SendsCorrectSequence() {
+        List<String> sentOutput = new ArrayList<>();
+        MockConnection connection = new MockConnection() {
+            @Override
+            public Consumer<int[]> stdoutHandler() {
+                return codePoints -> {
+                    StringBuilder sb = new StringBuilder();
+                    for (int cp : codePoints) {
+                        sb.appendCodePoint(cp);
+                    }
+                    sentOutput.add(sb.toString());
+                };
+            }
+        };
+
+        connection.enableGraphemeClusterMode();
+
+        assertFalse("Should have sent output", sentOutput.isEmpty());
+        assertTrue("Should have sent Mode 2027 enable sequence",
+                sentOutput.stream().anyMatch(s -> s.contains("\u001B[?2027h")));
+    }
+
+    @Test
+    public void testDisableGraphemeClusterMode_SendsCorrectSequence() {
+        List<String> sentOutput = new ArrayList<>();
+        MockConnection connection = new MockConnection() {
+            @Override
+            public Consumer<int[]> stdoutHandler() {
+                return codePoints -> {
+                    StringBuilder sb = new StringBuilder();
+                    for (int cp : codePoints) {
+                        sb.appendCodePoint(cp);
+                    }
+                    sentOutput.add(sb.toString());
+                };
+            }
+        };
+
+        connection.disableGraphemeClusterMode();
+
+        assertFalse("Should have sent output", sentOutput.isEmpty());
+        assertTrue("Should have sent Mode 2027 disable sequence",
+                sentOutput.stream().anyMatch(s -> s.contains("\u001B[?2027l")));
+    }
+
+    @Test
+    public void testSupportsGraphemeClusterMode_NullDevice() {
+        MockConnection connection = new MockConnection() {
+            @Override
+            public Device device() {
+                return null;
+            }
+        };
+
+        assertFalse("Should return false when device is null",
+                connection.supportsGraphemeClusterMode());
+    }
+
+    @Test
+    public void testSupportsGraphemeClusterMode_NoAnsi() {
+        MockConnection connection = new MockConnection() {
+            @Override
+            public boolean supportsAnsi() {
+                return false;
+            }
+        };
+
+        assertFalse("Should return false when ANSI not supported",
+                connection.supportsGraphemeClusterMode());
+    }
+
+    // ==================== Mock Connection ====================
+
+    private static class MockConnection implements Connection {
+        private Consumer<int[]> stdinHandler;
+        private Consumer<Size> sizeHandler;
+        private Consumer<Signal> signalHandler;
+        private Consumer<Void> closeHandler;
+        private Attributes attributes = new Attributes();
+        private final List<String> outputBuffer = new ArrayList<>();
+
+        @Override
+        public Device device() {
+            return new BaseDevice("xterm-256color") {
+                @Override
+                public boolean supportsOscQueries() {
+                    // Ensure tests do not depend on host environment OSC heuristics
+                    return true;
+                }
+            };
+        }
+
+        @Override
+        public Size size() {
+            return new Size(80, 24);
+        }
+
+        @Override
+        public Consumer<Size> getSizeHandler() {
+            return sizeHandler;
+        }
+
+        @Override
+        public void setSizeHandler(Consumer<Size> handler) {
+            this.sizeHandler = handler;
+        }
+
+        @Override
+        public Consumer<Signal> getSignalHandler() {
+            return signalHandler;
+        }
+
+        @Override
+        public void setSignalHandler(Consumer<Signal> handler) {
+            this.signalHandler = handler;
+        }
+
+        @Override
+        public Consumer<int[]> getStdinHandler() {
+            return stdinHandler;
+        }
+
+        @Override
+        public void setStdinHandler(Consumer<int[]> handler) {
+            this.stdinHandler = handler;
+        }
+
+        @Override
+        public Consumer<int[]> stdoutHandler() {
+            return codePoints -> {
+                StringBuilder sb = new StringBuilder();
+                for (int cp : codePoints) {
+                    sb.appendCodePoint(cp);
+                }
+                outputBuffer.add(sb.toString());
+            };
+        }
+
+        @Override
+        public void setCloseHandler(Consumer<Void> handler) {
+            this.closeHandler = handler;
+        }
+
+        @Override
+        public Consumer<Void> getCloseHandler() {
+            return closeHandler;
+        }
+
+        @Override
+        public void close() {
+            if (closeHandler != null) {
+                closeHandler.accept(null);
+            }
+        }
+
+        @Override
+        public void openBlocking() {
+        }
+
+        @Override
+        public void openNonBlocking() {
+        }
+
+        @Override
+        public boolean reading() {
+            return true;
+        }
+
+        @Override
+        public boolean put(Capability capability, Object... params) {
+            return false;
+        }
+
+        @Override
+        public Attributes getAttributes() {
+            return attributes;
+        }
+
+        @Override
+        public void setAttributes(Attributes attr) {
+            this.attributes = attr;
+        }
+
+        @Override
+        public Charset inputEncoding() {
+            return Charset.defaultCharset();
+        }
+
+        @Override
+        public Charset outputEncoding() {
+            return Charset.defaultCharset();
+        }
+
+        @Override
+        public boolean supportsAnsi() {
+            return true;
+        }
+
+        public void simulateInput(String input) {
+            if (stdinHandler != null) {
+                stdinHandler.accept(input.codePoints().toArray());
+            }
+        }
+    }
+}

--- a/terminal-api/src/test/java/org/aesh/terminal/utils/ANSIMode2027Test.java
+++ b/terminal-api/src/test/java/org/aesh/terminal/utils/ANSIMode2027Test.java
@@ -1,0 +1,206 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aesh.terminal.utils;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * Tests for Mode 2027 (grapheme cluster mode) ANSI constants and DECRPM parsing.
+ *
+ * @author Ståle Pedersen
+ */
+public class ANSIMode2027Test {
+
+    // ==================== Constants ====================
+
+    @Test
+    public void testMode2027QueryConstant() {
+        assertEquals("\u001B[?2027$p", ANSI.MODE_2027_QUERY);
+    }
+
+    @Test
+    public void testMode2027EnableConstant() {
+        assertEquals("\u001B[?2027h", ANSI.MODE_2027_ENABLE);
+    }
+
+    @Test
+    public void testMode2027DisableConstant() {
+        assertEquals("\u001B[?2027l", ANSI.MODE_2027_DISABLE);
+    }
+
+    // ==================== DECRPM Parser: Valid Responses ====================
+
+    @Test
+    public void testParseMode2027Response_Set() {
+        // Ps=1: mode is set (enabled)
+        String response = "\u001B[?2027;1$y";
+        int[] input = response.codePoints().toArray();
+
+        Boolean result = ANSI.parseMode2027Response(input);
+
+        assertNotNull("Should parse Ps=1 (set)", result);
+        assertTrue("Ps=1 means terminal supports Mode 2027", result);
+    }
+
+    @Test
+    public void testParseMode2027Response_Reset() {
+        // Ps=2: mode is reset (disabled, but recognized)
+        String response = "\u001B[?2027;2$y";
+        int[] input = response.codePoints().toArray();
+
+        Boolean result = ANSI.parseMode2027Response(input);
+
+        assertNotNull("Should parse Ps=2 (reset)", result);
+        assertTrue("Ps=2 means terminal recognizes Mode 2027", result);
+    }
+
+    @Test
+    public void testParseMode2027Response_PermanentlySet() {
+        // Ps=3: mode is permanently set
+        String response = "\u001B[?2027;3$y";
+        int[] input = response.codePoints().toArray();
+
+        Boolean result = ANSI.parseMode2027Response(input);
+
+        assertNotNull("Should parse Ps=3 (permanently set)", result);
+        assertTrue("Ps=3 means terminal supports Mode 2027", result);
+    }
+
+    @Test
+    public void testParseMode2027Response_NotRecognized() {
+        // Ps=0: mode is not recognized
+        String response = "\u001B[?2027;0$y";
+        int[] input = response.codePoints().toArray();
+
+        Boolean result = ANSI.parseMode2027Response(input);
+
+        assertNotNull("Should parse Ps=0 (not recognized)", result);
+        assertFalse("Ps=0 means terminal does not support Mode 2027", result);
+    }
+
+    @Test
+    public void testParseMode2027Response_PermanentlyReset() {
+        // Ps=4: mode is permanently reset
+        String response = "\u001B[?2027;4$y";
+        int[] input = response.codePoints().toArray();
+
+        Boolean result = ANSI.parseMode2027Response(input);
+
+        assertNotNull("Should parse Ps=4 (permanently reset)", result);
+        assertFalse("Ps=4 means terminal does not support Mode 2027", result);
+    }
+
+    // ==================== DECRPM Parser: Invalid/Edge Cases ====================
+
+    @Test
+    public void testParseMode2027Response_NullInput() {
+        assertNull("Should return null for null input", ANSI.parseMode2027Response(null));
+    }
+
+    @Test
+    public void testParseMode2027Response_EmptyInput() {
+        assertNull("Should return null for empty input", ANSI.parseMode2027Response(new int[0]));
+    }
+
+    @Test
+    public void testParseMode2027Response_TooShortInput() {
+        // Less than 9 characters
+        int[] input = new int[] { 27, '[', '?', '2' };
+        assertNull("Should return null for too short input", ANSI.parseMode2027Response(input));
+    }
+
+    @Test
+    public void testParseMode2027Response_MissingTerminator() {
+        // Valid prefix but no "$y" terminator
+        String response = "\u001B[?2027;1";
+        int[] input = response.codePoints().toArray();
+
+        assertNull("Should return null when terminator is missing", ANSI.parseMode2027Response(input));
+    }
+
+    @Test
+    public void testParseMode2027Response_WrongModeNumber() {
+        // DECRPM for a different mode (not 2027)
+        String response = "\u001B[?1;1$y";
+        int[] input = response.codePoints().toArray();
+
+        assertNull("Should return null for wrong mode number", ANSI.parseMode2027Response(input));
+    }
+
+    @Test
+    public void testParseMode2027Response_MalformedNoSemicolon() {
+        String response = "\u001B[?20271$y";
+        int[] input = response.codePoints().toArray();
+
+        assertNull("Should return null for malformed response without semicolon",
+                ANSI.parseMode2027Response(input));
+    }
+
+    @Test
+    public void testParseMode2027Response_UnknownPsValue() {
+        // Ps=5 is not defined in the DECRPM spec
+        String response = "\u001B[?2027;5$y";
+        int[] input = response.codePoints().toArray();
+
+        assertNull("Should return null for unknown Ps value", ANSI.parseMode2027Response(input));
+    }
+
+    @Test
+    public void testParseMode2027Response_NonNumericPs() {
+        String response = "\u001B[?2027;x$y";
+        int[] input = response.codePoints().toArray();
+
+        assertNull("Should return null for non-numeric Ps", ANSI.parseMode2027Response(input));
+    }
+
+    @Test
+    public void testParseMode2027Response_EmptyPs() {
+        String response = "\u001B[?2027;$y";
+        int[] input = response.codePoints().toArray();
+
+        assertNull("Should return null for empty Ps", ANSI.parseMode2027Response(input));
+    }
+
+    @Test
+    public void testParseMode2027Response_WithPrefixNoise() {
+        // Response with leading noise (common in real terminal I/O)
+        String response = "some noise\u001B[?2027;1$y";
+        int[] input = response.codePoints().toArray();
+
+        Boolean result = ANSI.parseMode2027Response(input);
+
+        assertNotNull("Should parse response with prefix noise", result);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testParseMode2027Response_WithTrailingData() {
+        // Response with trailing data
+        String response = "\u001B[?2027;2$yextra data";
+        int[] input = response.codePoints().toArray();
+
+        Boolean result = ANSI.parseMode2027Response(input);
+
+        assertNotNull("Should parse response with trailing data", result);
+        assertTrue(result);
+    }
+}

--- a/terminal-api/src/test/java/org/aesh/terminal/utils/WcWidthTest.java
+++ b/terminal-api/src/test/java/org/aesh/terminal/utils/WcWidthTest.java
@@ -40,4 +40,111 @@ public class WcWidthTest {
         assertEquals(-1, org.aesh.terminal.utils.WcWidth.width('\u001B'));
     }
 
+    // ==================== Emoji Width Tests ====================
+
+    @Test
+    public void testEmojiWidth_MiscSymbolsAndPictographs() {
+        // U+1F300 Cyclone (start of range)
+        assertEquals(2, WcWidth.width(0x1F300));
+        // U+1F4A9 Pile of Poo
+        assertEquals(2, WcWidth.width(0x1F4A9));
+        // U+1F5FF Moyai (end of range)
+        assertEquals(2, WcWidth.width(0x1F5FF));
+    }
+
+    @Test
+    public void testEmojiWidth_Emoticons() {
+        // U+1F600 Grinning Face
+        assertEquals(2, WcWidth.width(0x1F600));
+        // U+1F60D Heart Eyes
+        assertEquals(2, WcWidth.width(0x1F60D));
+        // U+1F64F Person with Folded Hands (end of range)
+        assertEquals(2, WcWidth.width(0x1F64F));
+    }
+
+    @Test
+    public void testEmojiWidth_TransportAndMap() {
+        // U+1F680 Rocket
+        assertEquals(2, WcWidth.width(0x1F680));
+        // U+1F6FF (end of range)
+        assertEquals(2, WcWidth.width(0x1F6FF));
+    }
+
+    @Test
+    public void testEmojiWidth_SupplementalSymbols() {
+        // U+1F900 (start of Supplemental Symbols)
+        assertEquals(2, WcWidth.width(0x1F900));
+        // U+1F9FF (end of Supplemental Symbols)
+        assertEquals(2, WcWidth.width(0x1F9FF));
+    }
+
+    @Test
+    public void testEmojiWidth_SymbolsExtendedA() {
+        // U+1FA70 (start of Symbols Extended-A)
+        assertEquals(2, WcWidth.width(0x1FA70));
+        // U+1FAFF (end of range)
+        assertEquals(2, WcWidth.width(0x1FAFF));
+    }
+
+    @Test
+    public void testEmojiWidth_GeometricShapesExtendedEmoji() {
+        // Only the colored emoji circles/squares (U+1F7E0-U+1F7EB) have Emoji_Presentation
+        assertEquals(2, WcWidth.width(0x1F7E0)); // Large Orange Circle
+        assertEquals(2, WcWidth.width(0x1F7EB)); // Large Brown Square
+    }
+
+    @Test
+    public void testNonEmojiBlocks_Width1() {
+        // Alchemical Symbols (U+1F700-1F77F) are NOT emoji, should be width 1
+        assertEquals(1, WcWidth.width(0x1F700));
+        assertEquals(1, WcWidth.width(0x1F77F));
+        // Supplemental Arrows-C (U+1F800-1F8FF) are NOT emoji, should be width 1
+        assertEquals(1, WcWidth.width(0x1F800));
+        assertEquals(1, WcWidth.width(0x1F8FF));
+        // Non-emoji part of Geometric Shapes Extended (before U+1F7E0) should be width 1
+        assertEquals(1, WcWidth.width(0x1F780));
+        // Chess Symbols (U+1FA00-1FA6F) are NOT emoji (no Emoji_Presentation), should be width 1
+        assertEquals(1, WcWidth.width(0x1FA00));
+        assertEquals(1, WcWidth.width(0x1FA6F));
+    }
+
+    @Test
+    public void testEmojiWidth_SkinToneModifiers() {
+        // Emoji_Modifier characters U+1F3FB-U+1F3FF are width 2 when standalone
+        // (they render as visible colored squares; when combined with a preceding
+        // emoji via Mode 2027 grapheme clustering, they form a skin-toned emoji)
+        assertEquals(2, WcWidth.width(0x1F3FB));
+        assertEquals(2, WcWidth.width(0x1F3FF));
+    }
+
+    @Test
+    public void testZeroWidthJoiner() {
+        // U+200D ZWJ should be zero-width (it's in the COMBINING table)
+        assertEquals(0, WcWidth.width(0x200D));
+    }
+
+    @Test
+    public void testVariationSelectorsSupplementInCombining() {
+        // Variation Selectors Supplement U+E0100-U+E01EF should be zero-width
+        assertEquals(0, WcWidth.width(0xE0100));
+        assertEquals(0, WcWidth.width(0xE01EF));
+    }
+
+    @Test
+    public void testCjkStillWidth2() {
+        // CJK characters should still be width 2
+        assertEquals(2, WcWidth.width(0x4E00)); // CJK Unified Ideograph
+        assertEquals(2, WcWidth.width(0x3000)); // Ideographic Space (CJK)
+        assertEquals(2, WcWidth.width(0xAC00)); // Hangul Syllable
+    }
+
+    @Test
+    public void testAsciiStillWidth1() {
+        // ASCII characters should still be width 1
+        assertEquals(1, WcWidth.width('A'));
+        assertEquals(1, WcWidth.width('z'));
+        assertEquals(1, WcWidth.width('0'));
+        assertEquals(1, WcWidth.width(' '));
+    }
+
 }


### PR DESCRIPTION
Add infrastructure for Mode 2027 terminal protocol which enables UAX #29 grapheme cluster segmentation for correct cursor positioning with multi-codepoint characters (ZWJ emoji, flag sequences, etc.).

- ANSI: add DECRQM/DECRPM constants and parser for Mode 2027
- Device: add supportsGraphemeClusterMode to TerminalType enum (true for Ghostty, WezTerm, Kitty, Contour, Foot)
- TerminalEnvironment: add supportsGraphemeClusterMode delegation
- Connection: add query/enable/disable methods for Mode 2027
- WcWidth: add emoji ranges U+1F300-1FAFF as width-2