### PR TITLE
Add lightweight terminal-detect module

### DIFF
--- a/examples/src/main/java/org/aesh/terminal/tty/example/ImageExample.java
+++ b/examples/src/main/java/org/aesh/terminal/tty/example/ImageExample.java
@@ -29,7 +29,7 @@ import java.nio.file.Paths;
 import javax.imageio.ImageIO;
 
 import org.aesh.terminal.Attributes;
-import org.aesh.terminal.image.ImageProtocol;
+import org.aesh.terminal.detect.ImageProtocol;
 import org.aesh.terminal.image.TerminalImage;
 import org.aesh.terminal.image.TerminalImageBuilder;
 import org.aesh.terminal.tty.Signal;

--- a/examples/src/main/java/org/aesh/terminal/tty/example/SyncImageDemoExample.java
+++ b/examples/src/main/java/org/aesh/terminal/tty/example/SyncImageDemoExample.java
@@ -30,7 +30,7 @@ import org.aesh.terminal.Attributes;
 import org.aesh.terminal.formatting.Color;
 import org.aesh.terminal.formatting.TerminalColor;
 import org.aesh.terminal.formatting.TerminalString;
-import org.aesh.terminal.image.ImageProtocol;
+import org.aesh.terminal.detect.ImageProtocol;
 import org.aesh.terminal.image.TerminalImage;
 import org.aesh.terminal.image.TerminalImageBuilder;
 import org.aesh.terminal.tty.Signal;

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     </scm>
 
     <modules>
+        <module>terminal-detect</module>
         <module>terminal-api</module>
         <module>readline-api</module>
         <module>terminal-tty</module>

--- a/terminal-api/pom.xml
+++ b/terminal-api/pom.xml
@@ -68,6 +68,11 @@
 
    <dependencies>
       <dependency>
+         <groupId>org.aesh</groupId>
+         <artifactId>terminal-detect</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
          <version>4.13.2</version>

--- a/terminal-api/src/main/java/org/aesh/terminal/AbstractConnection.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/AbstractConnection.java
@@ -21,9 +21,9 @@ package org.aesh.terminal;
 
 import java.util.function.Consumer;
 
+import org.aesh.terminal.detect.TerminalTheme;
 import org.aesh.terminal.tty.Signal;
 import org.aesh.terminal.tty.Size;
-import org.aesh.terminal.utils.TerminalTheme;
 
 /**
  * Abstract base class for {@link Connection} implementations that use an

--- a/terminal-api/src/main/java/org/aesh/terminal/Connection.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/Connection.java
@@ -25,12 +25,12 @@ import java.nio.charset.Charset;
 import java.util.EnumSet;
 import java.util.function.Consumer;
 
+import org.aesh.terminal.detect.TerminalTheme;
 import org.aesh.terminal.io.Encoder;
 import org.aesh.terminal.tty.Capability;
 import org.aesh.terminal.tty.Signal;
 import org.aesh.terminal.tty.Size;
 import org.aesh.terminal.utils.Parser;
-import org.aesh.terminal.utils.TerminalTheme;
 
 /**
  * Represent a connection to either a local/direct/remote Terminal.

--- a/terminal-api/src/main/java/org/aesh/terminal/Device.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/Device.java
@@ -24,7 +24,7 @@ import java.util.EnumSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import org.aesh.terminal.image.ImageProtocol;
+import org.aesh.terminal.detect.ImageProtocol;
 import org.aesh.terminal.image.ImageProtocolDetector;
 import org.aesh.terminal.tty.Capability;
 import org.aesh.terminal.utils.ColorDepth;

--- a/terminal-api/src/main/java/org/aesh/terminal/EventDecoder.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/EventDecoder.java
@@ -24,9 +24,9 @@ import java.util.Arrays;
 import java.util.Queue;
 import java.util.function.Consumer;
 
+import org.aesh.terminal.detect.TerminalTheme;
 import org.aesh.terminal.tty.Signal;
 import org.aesh.terminal.utils.ANSI;
-import org.aesh.terminal.utils.TerminalTheme;
 
 /**
  * Decodes terminal input events, separating signals (INT, SUSP, EOF) and

--- a/terminal-api/src/main/java/org/aesh/terminal/TerminalFeatures.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/TerminalFeatures.java
@@ -27,7 +27,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.aesh.terminal.image.ImageProtocol;
+import org.aesh.terminal.detect.ImageProtocol;
+import org.aesh.terminal.detect.TerminalTheme;
 import org.aesh.terminal.image.ImageProtocolDetector;
 import org.aesh.terminal.tty.Capability;
 import org.aesh.terminal.tty.Point;
@@ -35,7 +36,6 @@ import org.aesh.terminal.utils.ANSI;
 import org.aesh.terminal.utils.CodePointUtils;
 import org.aesh.terminal.utils.ColorDepth;
 import org.aesh.terminal.utils.TerminalColorCapability;
-import org.aesh.terminal.utils.TerminalTheme;
 
 /**
  * Advanced terminal features: queries, capability detection, semantic output,

--- a/terminal-api/src/main/java/org/aesh/terminal/formatting/TerminalColor.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/formatting/TerminalColor.java
@@ -21,10 +21,10 @@ package org.aesh.terminal.formatting;
 
 import java.io.PrintStream;
 
+import org.aesh.terminal.detect.TerminalTheme;
 import org.aesh.terminal.utils.ANSI;
 import org.aesh.terminal.utils.ColorDepth;
 import org.aesh.terminal.utils.TerminalColorCapability;
-import org.aesh.terminal.utils.TerminalTheme;
 
 /**
  * Represents a combination of foreground and background colors for terminal output.

--- a/terminal-api/src/main/java/org/aesh/terminal/image/ITermImage.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/image/ITermImage.java
@@ -24,6 +24,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
 
+import org.aesh.terminal.detect.ImageProtocol;
+
 /**
  * iTerm2 inline images protocol implementation.
  * <p>

--- a/terminal-api/src/main/java/org/aesh/terminal/image/ImageProtocolDetector.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/image/ImageProtocolDetector.java
@@ -21,6 +21,7 @@ package org.aesh.terminal.image;
 
 import org.aesh.terminal.Device;
 import org.aesh.terminal.DeviceAttributes;
+import org.aesh.terminal.detect.ImageProtocol;
 import org.aesh.terminal.utils.TerminalEnvironment;
 
 /**

--- a/terminal-api/src/main/java/org/aesh/terminal/image/KittyImage.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/image/KittyImage.java
@@ -25,6 +25,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
 
+import org.aesh.terminal.detect.ImageProtocol;
+
 /**
  * Kitty graphics protocol implementation.
  * <p>

--- a/terminal-api/src/main/java/org/aesh/terminal/image/SixelImage.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/image/SixelImage.java
@@ -34,6 +34,7 @@ import java.util.Map;
 
 import javax.imageio.ImageIO;
 
+import org.aesh.terminal.detect.ImageProtocol;
 import org.aesh.terminal.utils.TerminalEnvironment;
 
 /**

--- a/terminal-api/src/main/java/org/aesh/terminal/image/TerminalImage.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/image/TerminalImage.java
@@ -19,6 +19,8 @@
  */
 package org.aesh.terminal.image;
 
+import org.aesh.terminal.detect.ImageProtocol;
+
 /**
  * Represents an image that can be displayed in a terminal.
  * Different implementations handle different terminal image protocols.

--- a/terminal-api/src/main/java/org/aesh/terminal/image/TerminalImageBuilder.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/image/TerminalImageBuilder.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.aesh.terminal.Device;
+import org.aesh.terminal.detect.ImageProtocol;
 
 /**
  * Builder for creating terminal images with automatic protocol detection.

--- a/terminal-api/src/main/java/org/aesh/terminal/utils/ANSI.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/utils/ANSI.java
@@ -22,6 +22,7 @@ package org.aesh.terminal.utils;
 import java.util.Arrays;
 
 import org.aesh.terminal.DeviceAttributes;
+import org.aesh.terminal.detect.TerminalTheme;
 import org.aesh.terminal.tty.Point;
 
 /**

--- a/terminal-api/src/main/java/org/aesh/terminal/utils/TerminalColorCapability.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/utils/TerminalColorCapability.java
@@ -19,6 +19,8 @@
  */
 package org.aesh.terminal.utils;
 
+import org.aesh.terminal.detect.TerminalTheme;
+
 /**
  * Represents the detected color capabilities of a terminal.
  * <p>

--- a/terminal-api/src/main/java/org/aesh/terminal/utils/TerminalEnvironment.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/utils/TerminalEnvironment.java
@@ -20,6 +20,7 @@
 package org.aesh.terminal.utils;
 
 import org.aesh.terminal.Device;
+import org.aesh.terminal.detect.TerminalCapabilities;
 
 /**
  * Centralized utility for detecting terminal environment.
@@ -70,7 +71,6 @@ public final class TerminalEnvironment {
     private final boolean inTmux;
     private final boolean inScreen;
     private final boolean tmuxPassthroughEnabled;
-    private final boolean windowsTerminalByProcess;
 
     /**
      * Private constructor - use {@link #getInstance()} or static methods.
@@ -101,7 +101,6 @@ public final class TerminalEnvironment {
         this.inTmux = tmux != null && !tmux.isEmpty();
         this.inScreen = term != null && term.toLowerCase().startsWith("screen");
         this.tmuxPassthroughEnabled = computeTmuxPassthrough();
-        this.windowsTerminalByProcess = detectWindowsTerminalByRegistry();
         this.terminalType = computeTerminalType();
         this.defaultColorDepth = computeColorDepth();
     }
@@ -233,15 +232,17 @@ public final class TerminalEnvironment {
      * Check if running in Windows Terminal.
      * <p>
      * Detects via environment variables (WT_SESSION, WT_PROFILE_ID) first.
-     * When Windows Terminal is the default terminal app but CMD/PowerShell
-     * is launched from its own shortcut, those env vars are absent. In that
-     * case, falls back to checking the process tree for WindowsTerminal.exe
-     * or OpenConsole.exe (requires Java 9+).
+     * When those are absent (e.g., CMD/PowerShell launched from its own
+     * shortcut while WT is the default terminal), falls back to
+     * {@link TerminalCapabilities} which checks the Windows Registry.
      *
      * @return true if running inside Windows Terminal
      */
     public boolean isWindowsTerminal() {
-        return wtSession != null || wtProfileId != null || windowsTerminalByProcess;
+        if (wtSession != null || wtProfileId != null) {
+            return true;
+        }
+        return "windows-terminal".equals(TerminalCapabilities.getInstance().terminalName());
     }
 
     /**
@@ -594,118 +595,15 @@ public final class TerminalEnvironment {
         return Device.TerminalType.UNKNOWN;
     }
 
-    /**
-     * Check the Windows Registry for the default terminal application.
-     * When Windows Terminal is the default but CMD/PowerShell is launched
-     * from its own shortcut, WT_SESSION/WT_PROFILE_ID are not set because
-     * WT hosts the console via ConPTY as a sibling process. The registry
-     * key {@code HKCU\Console\%%Startup\DelegationTerminal} contains the
-     * GUID of the configured default terminal app.
-     */
-    private static boolean detectWindowsTerminalByRegistry() {
-        if (!System.getProperty("os.name", "").toLowerCase().contains("windows")) {
-            return false;
-        }
-        try {
-            String delegation = regQuery(
-                    "HKCU\\Console\\%%Startup", "DelegationTerminal");
-            if (delegation == null) {
-                return false;
-            }
-            String lower = delegation.toLowerCase();
-            // Explicit Windows Terminal GUID (stable or preview)
-            if (lower.contains("{2eaca947-7f5f-4cfa-ba87-8f7fbeefbe69}")
-                    || lower.contains("{e12cff52-a866-4c77-9a90-f570a7aa2c6b}")) {
-                return true;
-            }
-            // "Let Windows decide" (null GUID) — uses WT if installed
-            if (lower.contains("{00000000-0000-0000-0000-000000000000}")) {
-                return isWindowsTerminalInstalled();
-            }
-            return false;
-        } catch (Exception ignored) {
-            return false;
-        }
-    }
-
-    private static boolean isWindowsTerminalInstalled() {
-        String path = regQuery(
-                "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\wt.exe",
-                "Path");
-        return path != null && !path.trim().isEmpty();
-    }
-
-    /**
-     * Query a Windows Registry value. Parses the {@code REG_SZ} value
-     * from the {@code reg query} output format:
-     *
-     * <pre>
-     *     ValueName    REG_SZ    ActualValue
-     * </pre>
-     *
-     * @return the extracted value, or null if the key/value doesn't exist
-     */
-    private static String regQuery(String key, String valueName) {
-        try {
-            Process process = new ProcessBuilder("reg", "query", key, "/v", valueName)
-                    .redirectErrorStream(true)
-                    .start();
-            byte[] buf = new byte[1024];
-            StringBuilder sb = new StringBuilder();
-            int n;
-            while ((n = process.getInputStream().read(buf)) != -1) {
-                sb.append(new String(buf, 0, n));
-            }
-            process.waitFor();
-            if (process.exitValue() != 0) {
-                return null;
-            }
-            // Parse value from "    Name    REG_SZ    Value" line
-            for (String line : sb.toString().split("\\r?\\n")) {
-                int idx = line.indexOf("REG_SZ");
-                if (idx >= 0) {
-                    return line.substring(idx + 6).trim();
-                }
-            }
-            return null;
-        } catch (Exception ignored) {
-            return null;
-        }
-    }
-
     private ColorDepth computeColorDepth() {
-        // Priority 1: COLORTERM
-        if (isTrueColorIndicated()) {
+        TerminalCapabilities caps = TerminalCapabilities.getInstance();
+        if (caps.supportsTrueColor()) {
             return ColorDepth.TRUE_COLOR;
         }
-
-        // Priority 2: TERM suffix
-        if (term != null) {
-            String termLower = term.toLowerCase();
-            if (termLower.contains("truecolor") || termLower.contains("24bit") ||
-                    termLower.contains("direct")) {
-                return ColorDepth.TRUE_COLOR;
-            }
-            if (termLower.contains("256color") || termLower.contains("256-color")) {
-                return ColorDepth.COLORS_256;
-            }
+        if (caps.supports256Colors()) {
+            return ColorDepth.COLORS_256;
         }
-
-        // Priority 3: Known terminal type
-        if (terminalType != null && terminalType != Device.TerminalType.UNKNOWN) {
-            return terminalType.getDefaultColorDepth();
-        }
-
-        // Priority 4: OS-based detection (modern Windows)
-        String osName = System.getProperty("os.name", "").toLowerCase();
-        if (osName.contains("windows 10") || osName.contains("windows 11") ||
-                osName.contains("windows server 2016") || osName.contains("windows server 2019") ||
-                osName.contains("windows server 2022")) {
-            return ColorDepth.TRUE_COLOR;
-        }
-
-        // Default
-        return ColorDepth.COLORS_256;
+        return ColorDepth.COLORS_8;
     }
 
     // ==================== Static Convenience Methods ====================

--- a/terminal-api/src/test/java/org/aesh/terminal/EventDecoderThemeDsrTest.java
+++ b/terminal-api/src/test/java/org/aesh/terminal/EventDecoderThemeDsrTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.aesh.terminal.utils.TerminalTheme;
+import org.aesh.terminal.detect.TerminalTheme;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/terminal-api/src/test/java/org/aesh/terminal/image/ITermImageTest.java
+++ b/terminal-api/src/test/java/org/aesh/terminal/image/ITermImageTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.*;
 
 import java.util.Base64;
 
+import org.aesh.terminal.detect.ImageProtocol;
 import org.junit.Test;
 
 public class ITermImageTest {

--- a/terminal-api/src/test/java/org/aesh/terminal/image/KittyImageTest.java
+++ b/terminal-api/src/test/java/org/aesh/terminal/image/KittyImageTest.java
@@ -21,6 +21,7 @@ package org.aesh.terminal.image;
 
 import static org.junit.Assert.*;
 
+import org.aesh.terminal.detect.ImageProtocol;
 import org.junit.Test;
 
 public class KittyImageTest {

--- a/terminal-api/src/test/java/org/aesh/terminal/image/SixelImageTest.java
+++ b/terminal-api/src/test/java/org/aesh/terminal/image/SixelImageTest.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayOutputStream;
 
 import javax.imageio.ImageIO;
 
+import org.aesh.terminal.detect.ImageProtocol;
 import org.junit.Test;
 
 public class SixelImageTest {

--- a/terminal-api/src/test/java/org/aesh/terminal/image/TerminalImageBuilderTest.java
+++ b/terminal-api/src/test/java/org/aesh/terminal/image/TerminalImageBuilderTest.java
@@ -21,6 +21,7 @@ package org.aesh.terminal.image;
 
 import static org.junit.Assert.*;
 
+import org.aesh.terminal.detect.ImageProtocol;
 import org.junit.Test;
 
 public class TerminalImageBuilderTest {

--- a/terminal-api/src/test/java/org/aesh/terminal/utils/ANSIBuilderTest.java
+++ b/terminal-api/src/test/java/org/aesh/terminal/utils/ANSIBuilderTest.java
@@ -22,6 +22,7 @@ package org.aesh.terminal.utils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.aesh.terminal.detect.TerminalTheme;
 import org.aesh.terminal.formatting.Color;
 import org.aesh.terminal.utils.ANSIBuilder.TextType;
 import org.junit.Test;

--- a/terminal-api/src/test/java/org/aesh/terminal/utils/ANSIOscTest.java
+++ b/terminal-api/src/test/java/org/aesh/terminal/utils/ANSIOscTest.java
@@ -21,6 +21,7 @@ package org.aesh.terminal.utils;
 
 import static org.junit.Assert.*;
 
+import org.aesh.terminal.detect.TerminalTheme;
 import org.junit.Test;
 
 /**

--- a/terminal-api/src/test/java/org/aesh/terminal/utils/TerminalColorCapabilityTest.java
+++ b/terminal-api/src/test/java/org/aesh/terminal/utils/TerminalColorCapabilityTest.java
@@ -21,6 +21,7 @@ package org.aesh.terminal.utils;
 
 import static org.junit.Assert.*;
 
+import org.aesh.terminal.detect.TerminalTheme;
 import org.junit.Test;
 
 /**

--- a/terminal-detect/pom.xml
+++ b/terminal-detect/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ JBoss, Home of Professional Open Source
+~ Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+~ as indicated by the @authors tag. All rights reserved.
+~ See the copyright.txt in the distribution for a
+~ full listing of individual contributors.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~ http://www.apache.org/licenses/LICENSE-2.0
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.aesh</groupId>
+        <artifactId>readline-all</artifactId>
+        <version>3.8-dev</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>terminal-detect</artifactId>
+    <packaging>jar</packaging>
+    <name>Æsh Terminal Detection</name>
+    <description>Lightweight terminal capability detection with zero dependencies</description>
+    <scm>
+        <connection>scm:git:git://github.com/aeshell/aesh-readline.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/aeshell/aesh-readline.git</developerConnection>
+        <url>https://github.com/aeshell/aesh-readline/tree/master</url>
+    </scm>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <javaModuleName>org.aesh.terminal.detect</javaModuleName>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
+                        </manifestEntries>
+                        <index>true</index>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/terminal-detect/src/main/java/org/aesh/terminal/detect/ImageProtocol.java
+++ b/terminal-detect/src/main/java/org/aesh/terminal/detect/ImageProtocol.java
@@ -17,35 +17,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.aesh.terminal.image;
+package org.aesh.terminal.detect;
 
 /**
- * Supported terminal image protocols.
+ * Terminal image display protocols.
  */
 public enum ImageProtocol {
-    /**
-     * No image protocol supported.
-     */
     NONE,
-
-    /**
-     * iTerm2 inline images protocol.
-     * Supported by: iTerm2, WezTerm, Mintty, VSCode terminal, Tabby, Hyper
-     * Format: OSC 1337 ; File=[args]:base64data BEL
-     */
-    ITERM2,
-
-    /**
-     * Kitty graphics protocol.
-     * Supported by: Kitty, Konsole (partial)
-     * Format: APC G [control];[payload] ST
-     */
     KITTY,
-
-    /**
-     * Sixel graphics protocol.
-     * Supported by: xterm, mlterm, foot, Windows Terminal, etc.
-     * Not currently implemented.
-     */
+    ITERM2,
     SIXEL
 }

--- a/terminal-detect/src/main/java/org/aesh/terminal/detect/TerminalCapabilities.java
+++ b/terminal-detect/src/main/java/org/aesh/terminal/detect/TerminalCapabilities.java
@@ -1,0 +1,404 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aesh.terminal.detect;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Lightweight terminal capability detection.
+ * <p>
+ * Detects terminal features using environment variables and heuristics
+ * without requiring a terminal connection or any external dependencies.
+ * <p>
+ * Usage:
+ *
+ * <pre>
+ * // Fast heuristic detection (~1-2ms)
+ * TerminalCapabilities caps = TerminalCapabilities.detect();
+ *
+ * // Async detection with background color queries
+ * TerminalCapabilities caps = TerminalCapabilities.detectAsync();
+ * // ... do other startup work ...
+ * caps.awaitColors(500, TimeUnit.MILLISECONDS);
+ * int[] bg = caps.backgroundRGB(); // available once query completes
+ * </pre>
+ */
+public final class TerminalCapabilities {
+
+    private static volatile TerminalCapabilities instance;
+
+    private final TerminalDetector detector;
+    private volatile TerminalTheme resolvedTheme;
+    private volatile int[] foregroundRGB;
+    private volatile int[] backgroundRGB;
+    private volatile Map<Integer, int[]> paletteColors;
+    private volatile Boolean queried256;
+    private volatile ImageProtocol queriedImageProtocol;
+    private final CountDownLatch colorQueryLatch;
+
+    private TerminalCapabilities(TerminalDetector detector, CountDownLatch latch) {
+        this.detector = detector;
+        this.colorQueryLatch = latch;
+    }
+
+    /**
+     * Get the shared instance, creating it lazily via {@link #detect()}.
+     * <p>
+     * Use {@link #setInstance(TerminalCapabilities)} to inject a pre-built
+     * instance from early startup (e.g., Quarkus bootstrap). For example,
+     * call {@code setInstance(detectAsync())} to enable background color
+     * queries before other modules initialize.
+     *
+     * @return the shared capabilities instance
+     */
+    public static TerminalCapabilities getInstance() {
+        if (instance == null) {
+            synchronized (TerminalCapabilities.class) {
+                if (instance == null) {
+                    instance = detect();
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * Set the shared instance. Call this early in application startup
+     * to make pre-detected capabilities available to all later consumers.
+     *
+     * @param caps the pre-detected capabilities
+     */
+    public static void setInstance(TerminalCapabilities caps) {
+        instance = caps;
+    }
+
+    /**
+     * Detect terminal capabilities from environment variables only.
+     * Fast (~1-2ms), no subprocess calls on Linux/macOS.
+     *
+     * @return the detected capabilities
+     */
+    public static TerminalCapabilities detect() {
+        return new TerminalCapabilities(new TerminalDetector(), null);
+    }
+
+    /**
+     * Detect terminal capabilities with full platform theme probing.
+     * <p>
+     * Same as {@link #detect()} but when the theme cannot be determined
+     * from environment variables, also checks platform-specific sources:
+     * <ul>
+     * <li>macOS: {@code defaults read -g AppleInterfaceStyle}</li>
+     * <li>Linux: {@code gsettings} (GNOME) or {@code kreadconfig5} (KDE)</li>
+     * <li>Windows: Apps dark mode registry key</li>
+     * </ul>
+     * This may take 10-50ms due to subprocess calls.
+     *
+     * @return the detected capabilities with resolved theme
+     */
+    public static TerminalCapabilities detectFull() {
+        TerminalCapabilities caps = detect();
+        if (caps.detector.theme == TerminalTheme.UNKNOWN) {
+            caps.resolvedTheme = TerminalDetector.detectPlatformTheme();
+        }
+        return caps;
+    }
+
+    /**
+     * Detect terminal capabilities and query actual colors in the background.
+     * <p>
+     * Returns immediately with heuristic results (~1-2ms). A daemon thread
+     * queries the terminal for foreground/background colors via OSC escape
+     * sequences. Use {@link #awaitColors(long, TimeUnit)} to wait for the
+     * query to complete, or check {@link #backgroundRGB()} / {@link #foregroundRGB()}
+     * which return {@code null} until the query finishes.
+     * <p>
+     * On platforms where terminal queries are not possible (Windows, pipes,
+     * containers, tmux without passthrough), the background thread completes
+     * immediately with no results and falls back to platform theme detection.
+     *
+     * @return the detected capabilities with background color query running
+     */
+    public static TerminalCapabilities detectAsync() {
+        TerminalDetector detector = new TerminalDetector();
+        CountDownLatch latch = new CountDownLatch(1);
+        TerminalCapabilities caps = new TerminalCapabilities(detector, latch);
+
+        Thread queryThread = new Thread(() -> {
+            try {
+                if (!detector.isInMultiplexer()) {
+                    TerminalColorQuery result = TerminalColorQuery.query();
+                    if (result != null) {
+                        caps.foregroundRGB = result.foreground;
+                        caps.backgroundRGB = result.background;
+                        caps.paletteColors = result.palette;
+                        caps.queried256 = result.supports256;
+                        if (result.supportsSixel && detector.imageProtocol == ImageProtocol.NONE) {
+                            caps.queriedImageProtocol = ImageProtocol.SIXEL;
+                        }
+                        if (result.background != null) {
+                            caps.resolvedTheme = themeFromRGB(result.background);
+                        }
+                    }
+                }
+                if (caps.resolvedTheme == null && detector.theme == TerminalTheme.UNKNOWN) {
+                    caps.resolvedTheme = TerminalDetector.detectPlatformTheme();
+                }
+            } finally {
+                latch.countDown();
+            }
+        }, "terminal-detect-color-query");
+        queryThread.setDaemon(true);
+        queryThread.start();
+
+        return caps;
+    }
+
+    /**
+     * Wait for the background color query to complete.
+     * <p>
+     * Only relevant when created via {@link #detectAsync()}. For other
+     * factory methods, this returns {@code true} immediately.
+     *
+     * @param timeout the maximum time to wait
+     * @param unit the time unit
+     * @return {@code true} if the query completed, {@code false} if timed out
+     * @throws InterruptedException if interrupted while waiting
+     */
+    public boolean awaitColors(long timeout, TimeUnit unit) throws InterruptedException {
+        if (colorQueryLatch == null) {
+            return true;
+        }
+        return colorQueryLatch.await(timeout, unit);
+    }
+
+    /**
+     * Check if the terminal supports 24-bit true color (16 million colors).
+     * <p>
+     * When created via {@link #detectAsync()}, this may upgrade to
+     * {@code true} after the color query confirms true color support
+     * (terminals that respond to OSC color queries support true color).
+     *
+     * @return true if true color is supported
+     */
+    public boolean supportsTrueColor() {
+        return detector.trueColor || foregroundRGB != null || backgroundRGB != null;
+    }
+
+    /**
+     * Check if the terminal supports at least 256 colors.
+     * Always true when {@link #supportsTrueColor()} is true.
+     * <p>
+     * When created via {@link #detectAsync()}, this may upgrade to
+     * {@code true} after the color query confirms 256-color support.
+     *
+     * @return true if 256 colors are supported
+     */
+    public boolean supports256Colors() {
+        return detector.colors256 || (queried256 != null && queried256);
+    }
+
+    /**
+     * Check if the terminal supports any color output.
+     *
+     * @return true if color is supported
+     */
+    public boolean supportsColor() {
+        return detector.colors256 || detector.trueColor;
+    }
+
+    /**
+     * Get the image display protocol supported by this terminal.
+     * <p>
+     * When created via {@link #detectAsync()}, this may upgrade from
+     * NONE to SIXEL after the DA1 query confirms Sixel support.
+     *
+     * @return the image protocol, or {@link ImageProtocol#NONE}
+     */
+    public ImageProtocol imageProtocol() {
+        return queriedImageProtocol != null ? queriedImageProtocol : detector.imageProtocol;
+    }
+
+    /**
+     * Get the terminal background theme.
+     * <p>
+     * When created via {@link #detectAsync()}, this may return a more
+     * accurate result after the color query completes (derived from
+     * the actual background RGB).
+     *
+     * @return the theme (DARK, LIGHT, or UNKNOWN)
+     */
+    public TerminalTheme theme() {
+        return resolvedTheme != null ? resolvedTheme : detector.theme;
+    }
+
+    /**
+     * Get the queried foreground color.
+     * <p>
+     * Only available after a successful color query via {@link #detectAsync()}.
+     *
+     * @return RGB array [r, g, b] (0-255 each), or {@code null} if not queried
+     */
+    public int[] foregroundRGB() {
+        return foregroundRGB;
+    }
+
+    /**
+     * Get the queried background color.
+     * <p>
+     * Only available after a successful color query via {@link #detectAsync()}.
+     *
+     * @return RGB array [r, g, b] (0-255 each), or {@code null} if not queried
+     */
+    public int[] backgroundRGB() {
+        return backgroundRGB;
+    }
+
+    /**
+     * Get the queried base 16 palette colors (ANSI colors 0-15).
+     * <p>
+     * Only available after a successful color query via {@link #detectAsync()}.
+     *
+     * @return map from color index (0-15) to RGB array [r, g, b], or empty map if not queried
+     */
+    public Map<Integer, int[]> paletteColors() {
+        Map<Integer, int[]> p = paletteColors;
+        return p != null ? Collections.unmodifiableMap(p) : Collections.<Integer, int[]> emptyMap();
+    }
+
+    /**
+     * Get a palette color by ANSI index (0-15).
+     *
+     * @param index the ANSI color index
+     * @return RGB array [r, g, b] (0-255 each), or {@code null} if not queried
+     */
+    public int[] paletteColor(int index) {
+        Map<Integer, int[]> p = paletteColors;
+        return p != null ? p.get(index) : null;
+    }
+
+    // ANSI standard color accessors (indices 0-7)
+
+    public int[] black() {
+        return paletteColor(0);
+    }
+
+    public int[] red() {
+        return paletteColor(1);
+    }
+
+    public int[] green() {
+        return paletteColor(2);
+    }
+
+    public int[] yellow() {
+        return paletteColor(3);
+    }
+
+    public int[] blue() {
+        return paletteColor(4);
+    }
+
+    public int[] magenta() {
+        return paletteColor(5);
+    }
+
+    public int[] cyan() {
+        return paletteColor(6);
+    }
+
+    public int[] white() {
+        return paletteColor(7);
+    }
+
+    // Bright color accessors (indices 8-15)
+
+    public int[] brightBlack() {
+        return paletteColor(8);
+    }
+
+    public int[] brightRed() {
+        return paletteColor(9);
+    }
+
+    public int[] brightGreen() {
+        return paletteColor(10);
+    }
+
+    public int[] brightYellow() {
+        return paletteColor(11);
+    }
+
+    public int[] brightBlue() {
+        return paletteColor(12);
+    }
+
+    public int[] brightMagenta() {
+        return paletteColor(13);
+    }
+
+    public int[] brightCyan() {
+        return paletteColor(14);
+    }
+
+    public int[] brightWhite() {
+        return paletteColor(15);
+    }
+
+    /**
+     * Get the detected terminal name.
+     *
+     * @return terminal name (e.g., "kitty", "ghostty", "iterm2", "unknown")
+     */
+    public String terminalName() {
+        return detector.terminalName;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("TerminalCapabilities{");
+        sb.append("terminal=").append(detector.terminalName);
+        sb.append(", trueColor=").append(detector.trueColor);
+        sb.append(", 256colors=").append(supports256Colors());
+        sb.append(", imageProtocol=").append(detector.imageProtocol);
+        sb.append(", theme=").append(theme());
+        if (foregroundRGB != null)
+            sb.append(", fg=").append(formatRGB(foregroundRGB));
+        if (backgroundRGB != null)
+            sb.append(", bg=").append(formatRGB(backgroundRGB));
+        if (paletteColors != null)
+            sb.append(", palette=").append(paletteColors.size()).append(" colors");
+        sb.append('}');
+        return sb.toString();
+    }
+
+    private static String formatRGB(int[] rgb) {
+        return "[" + rgb[0] + "," + rgb[1] + "," + rgb[2] + "]";
+    }
+
+    private static TerminalTheme themeFromRGB(int[] rgb) {
+        // Perceived luminance (ITU-R BT.601)
+        double luminance = 0.299 * rgb[0] + 0.587 * rgb[1] + 0.114 * rgb[2];
+        return luminance < 128 ? TerminalTheme.DARK : TerminalTheme.LIGHT;
+    }
+}

--- a/terminal-detect/src/main/java/org/aesh/terminal/detect/TerminalColorQuery.java
+++ b/terminal-detect/src/main/java/org/aesh/terminal/detect/TerminalColorQuery.java
@@ -1,0 +1,352 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aesh.terminal.detect;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Direct terminal color queries via OSC escape sequences.
+ * Uses /dev/tty and stty for raw terminal I/O without depending on terminal-api.
+ */
+final class TerminalColorQuery {
+
+    private static final File DEV_TTY = new File("/dev/tty");
+    // OSC 10/11: foreground/background
+    // OSC 4;N: palette color N
+    // Query param is "?" terminated by BEL
+    private static final char BEL = '\007';
+
+    int[] foreground;
+    int[] background;
+    Map<Integer, int[]> palette;
+    boolean supports256;
+    boolean supportsSixel;
+    int da1DeviceClass = -1;
+    List<Integer> da1Features;
+
+    TerminalColorQuery() {
+    }
+
+    static TerminalColorQuery query() {
+        if (!DEV_TTY.exists() || !DEV_TTY.canRead() || !DEV_TTY.canWrite()) {
+            return null;
+        }
+
+        String savedState = sttyGet();
+        if (savedState == null) {
+            return null;
+        }
+
+        try {
+            sttyRaw();
+
+            // Build batch: DA1 + OSC 10 (fg) + OSC 11 (bg) + OSC 4 for 0-15 + color 255
+            StringBuilder queries = new StringBuilder();
+            queries.append("\033[c"); // DA1 query
+            queries.append("\033]10;?").append(BEL);
+            queries.append("\033]11;?").append(BEL);
+            for (int i = 0; i <= 15; i++) {
+                queries.append("\033]4;").append(i).append(";?").append(BEL);
+            }
+            queries.append("\033]4;255;?").append(BEL);
+
+            try (FileOutputStream ttyOut = new FileOutputStream(DEV_TTY)) {
+                ttyOut.write(queries.toString().getBytes());
+                ttyOut.flush();
+            }
+
+            // 20 expected terminators: 1 DA1 + 19 OSC responses
+            String response = readResponse(20);
+            if (response == null || response.isEmpty()) {
+                return null;
+            }
+
+            TerminalColorQuery result = new TerminalColorQuery();
+            parseDA1Response(response, result);
+            result.foreground = parseOscColorResponse(response, 10, -1);
+            result.background = parseOscColorResponse(response, 11, -1);
+            result.palette = new LinkedHashMap<>();
+            for (int i = 0; i <= 15; i++) {
+                int[] color = parseOscColorResponse(response, 4, i);
+                if (color != null) {
+                    result.palette.put(i, color);
+                }
+            }
+            result.supports256 = parseOscColorResponse(response, 4, 255) != null;
+            return result;
+        } catch (IOException ignored) {
+            return null;
+        } finally {
+            sttyRestore(savedState);
+        }
+    }
+
+    private static String sttyGet() {
+        Process p = null;
+        try {
+            p = new ProcessBuilder("stty", "-g")
+                    .redirectInput(DEV_TTY)
+                    .redirectErrorStream(true)
+                    .start();
+            byte[] buf = new byte[256];
+            StringBuilder sb = new StringBuilder();
+            int n;
+            while ((n = p.getInputStream().read(buf)) != -1) {
+                sb.append(new String(buf, 0, n));
+            }
+            p.waitFor();
+            return p.exitValue() == 0 ? sb.toString().trim() : null;
+        } catch (Exception ignored) {
+            return null;
+        } finally {
+            if (p != null)
+                p.destroy();
+        }
+    }
+
+    private static void sttyRaw() {
+        Process p = null;
+        try {
+            p = new ProcessBuilder("stty", "-echo", "-icanon", "-ixon", "min", "0", "time", "5")
+                    .redirectInput(DEV_TTY)
+                    .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                    .redirectErrorStream(true)
+                    .start();
+            p.waitFor();
+        } catch (Exception ignored) {
+        } finally {
+            if (p != null)
+                p.destroy();
+        }
+    }
+
+    private static void sttyRestore(String savedState) {
+        Process p = null;
+        try {
+            p = new ProcessBuilder("stty", savedState)
+                    .redirectInput(DEV_TTY)
+                    .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                    .redirectErrorStream(true)
+                    .start();
+            p.waitFor();
+        } catch (Exception ignored) {
+        } finally {
+            if (p != null)
+                p.destroy();
+        }
+    }
+
+    private static String readResponse(int expectedResponses) throws IOException {
+        try (FileInputStream ttyIn = new FileInputStream(DEV_TTY)) {
+            byte[] buf = new byte[4096];
+            StringBuilder sb = new StringBuilder();
+            int n;
+            while ((n = ttyIn.read(buf)) > 0) {
+                sb.append(new String(buf, 0, n));
+                if (countTerminators(sb) >= expectedResponses) {
+                    break;
+                }
+            }
+            return sb.toString();
+        }
+    }
+
+    private static int countTerminators(StringBuilder sb) {
+        int count = 0;
+        boolean inCsi = false;
+        for (int i = 0; i < sb.length(); i++) {
+            char c = sb.charAt(i);
+            if (c == BEL) {
+                count++;
+                inCsi = false;
+            } else if (c == '\033') {
+                if (i + 1 < sb.length() && sb.charAt(i + 1) == '\\') {
+                    count++;
+                    i++;
+                } else if (i + 1 < sb.length() && sb.charAt(i + 1) == '[') {
+                    inCsi = true;
+                    i++;
+                }
+            } else if (inCsi && c == 'c') {
+                // DA1 response: ESC[?...c
+                count++;
+                inCsi = false;
+            } else if (inCsi && !Character.isDigit(c) && c != ';' && c != '?') {
+                inCsi = false;
+            }
+        }
+        return count;
+    }
+
+    // ==================== OSC Response Parsing ====================
+
+    /**
+     * Parse an OSC color response for a given code and optional parameter.
+     *
+     * @param response the raw terminal response
+     * @param oscCode the OSC code (4, 10, 11)
+     * @param oscParam the parameter index (-1 for none, 0-255 for palette)
+     */
+    static int[] parseOscColorResponse(String response, int oscCode, int oscParam) {
+        if (response == null || response.length() < 10) {
+            return null;
+        }
+
+        String oscMarker = "\033]" + oscCode + ";";
+        int searchFrom = 0;
+
+        while (true) {
+            int start = response.indexOf(oscMarker, searchFrom);
+            if (start < 0) {
+                return null;
+            }
+
+            int afterMarker = start + oscMarker.length();
+
+            if (oscParam >= 0) {
+                String paramMarker = oscParam + ";";
+                if (!response.substring(afterMarker).startsWith(paramMarker)) {
+                    searchFrom = afterMarker;
+                    continue;
+                }
+                afterMarker += paramMarker.length();
+            }
+
+            int rgbStart = response.indexOf("rgb:", afterMarker);
+            if (rgbStart < 0) {
+                return null;
+            }
+
+            int belPos = response.indexOf(BEL, afterMarker);
+            int stPos = response.indexOf("\033\\", afterMarker);
+            int terminatorPos = -1;
+            if (belPos >= 0 && stPos >= 0) {
+                terminatorPos = Math.min(belPos, stPos);
+            } else if (belPos >= 0) {
+                terminatorPos = belPos;
+            } else if (stPos >= 0) {
+                terminatorPos = stPos;
+            }
+
+            if (terminatorPos >= 0 && rgbStart > terminatorPos) {
+                searchFrom = terminatorPos + 1;
+                continue;
+            }
+
+            rgbStart += 4;
+
+            int end = response.indexOf(BEL, rgbStart);
+            if (end < 0) {
+                end = response.indexOf("\033\\", rgbStart);
+            }
+            if (end < 0) {
+                end = response.length();
+            }
+
+            String rgbPart = response.substring(rgbStart, end);
+            String[] parts = rgbPart.split("/");
+            return parseHexRgbParts(parts);
+        }
+    }
+
+    private static int[] parseHexRgbParts(String[] parts) {
+        if (parts.length != 3) {
+            return null;
+        }
+        try {
+            int[] rgb = new int[3];
+            for (int i = 0; i < 3; i++) {
+                String hex = parts[i].trim();
+                if (hex.isEmpty() || hex.length() > 4) {
+                    return null;
+                }
+                int raw = Integer.parseInt(hex, 16);
+                int value;
+                switch (hex.length()) {
+                    case 1:
+                        value = raw * 17;
+                        break;
+                    case 2:
+                        value = raw;
+                        break;
+                    case 3:
+                        value = raw >> 4;
+                        break;
+                    case 4:
+                        value = raw >> 8;
+                        break;
+                    default:
+                        return null;
+                }
+                rgb[i] = Math.min(255, Math.max(0, value));
+            }
+            return rgb;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    // ==================== DA1 Response Parsing ====================
+
+    private static final int DA1_FEATURE_SIXEL = 4;
+
+    /**
+     * Parse a DA1 (Primary Device Attributes) response.
+     * Format: ESC[?{class};{feat1};{feat2};...c
+     * Feature code 4 = Sixel graphics support.
+     */
+    static void parseDA1Response(String response, TerminalColorQuery result) {
+        // Find ESC[? ... c
+        int start = response.indexOf("\033[?");
+        if (start < 0) {
+            return;
+        }
+        int end = response.indexOf('c', start + 3);
+        if (end < 0) {
+            return;
+        }
+
+        String params = response.substring(start + 3, end);
+        String[] parts = params.split(";");
+        if (parts.length == 0) {
+            return;
+        }
+
+        try {
+            result.da1DeviceClass = Integer.parseInt(parts[0].trim());
+            result.da1Features = new ArrayList<>();
+            for (int i = 1; i < parts.length; i++) {
+                int feature = Integer.parseInt(parts[i].trim());
+                result.da1Features.add(feature);
+                if (feature == DA1_FEATURE_SIXEL) {
+                    result.supportsSixel = true;
+                }
+            }
+        } catch (NumberFormatException ignored) {
+        }
+    }
+}

--- a/terminal-detect/src/main/java/org/aesh/terminal/detect/TerminalDetector.java
+++ b/terminal-detect/src/main/java/org/aesh/terminal/detect/TerminalDetector.java
@@ -1,0 +1,450 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aesh.terminal.detect;
+
+/**
+ * All terminal detection logic in a single class.
+ * Reads environment variables once and caches the results.
+ */
+final class TerminalDetector {
+
+    // Environment variables
+    private final String term;
+    private final String termProgram;
+    private final String terminalEmulator;
+    private final String colorterm;
+    private final String kittyWindowId;
+    private final String ghosttyResourcesDir;
+    private final String weztermPane;
+    private final String itermSessionId;
+    private final String wtSession;
+    private final String wtProfileId;
+    private final String alacrittySocket;
+    private final String colorFgBg;
+    private final String appleInterfaceStyle;
+    private final boolean inTmux;
+    private final boolean inScreen;
+
+    // Computed results
+    final String terminalName;
+    final boolean trueColor;
+    final boolean colors256;
+    final ImageProtocol imageProtocol;
+    final TerminalTheme theme;
+
+    TerminalDetector() {
+        this.term = System.getenv("TERM");
+        this.termProgram = System.getenv("TERM_PROGRAM");
+        this.terminalEmulator = System.getenv("TERMINAL_EMULATOR");
+        this.colorterm = System.getenv("COLORTERM");
+        this.kittyWindowId = System.getenv("KITTY_WINDOW_ID");
+        this.ghosttyResourcesDir = System.getenv("GHOSTTY_RESOURCES_DIR");
+        this.weztermPane = System.getenv("WEZTERM_PANE");
+        this.itermSessionId = System.getenv("ITERM_SESSION_ID");
+        this.wtSession = System.getenv("WT_SESSION");
+        this.wtProfileId = System.getenv("WT_PROFILE_ID");
+        this.alacrittySocket = System.getenv("ALACRITTY_SOCKET");
+        this.colorFgBg = System.getenv("COLORFGBG");
+        this.appleInterfaceStyle = System.getenv("APPLE_INTERFACE_STYLE");
+        String tmux = System.getenv("TMUX");
+        this.inTmux = tmux != null && !tmux.isEmpty();
+        this.inScreen = term != null && term.toLowerCase().startsWith("screen");
+
+        this.terminalName = detectTerminalName();
+        this.trueColor = detectTrueColor();
+        this.colors256 = trueColor || detect256Colors();
+        this.imageProtocol = detectImageProtocol();
+        this.theme = detectTheme();
+    }
+
+    // ==================== Terminal Name Detection ====================
+
+    private String detectTerminalName() {
+        if (isJetBrains())
+            return "jetbrains";
+        if (kittyWindowId != null)
+            return "kitty";
+        if (ghosttyResourcesDir != null)
+            return "ghostty";
+        if (weztermPane != null)
+            return "wezterm";
+        if (itermSessionId != null)
+            return "iterm2";
+        if (isWindowsTerminal())
+            return "windows-terminal";
+        if (alacrittySocket != null)
+            return "alacritty";
+
+        if (termProgram != null) {
+            String lower = termProgram.toLowerCase();
+            if (lower.contains("iterm"))
+                return "iterm2";
+            if (lower.contains("apple_terminal") || lower.contains("terminal.app"))
+                return "apple-terminal";
+            if (lower.contains("vscode"))
+                return "vscode";
+            if (lower.contains("hyper"))
+                return "hyper";
+            if (lower.contains("tabby") || lower.contains("terminus"))
+                return "tabby";
+            if (lower.contains("mintty"))
+                return "mintty";
+        }
+
+        if (term != null) {
+            String lower = term.toLowerCase();
+            if (lower.contains("kitty"))
+                return "kitty";
+            if (lower.contains("ghostty"))
+                return "ghostty";
+            if (lower.contains("foot"))
+                return "foot";
+            if (lower.contains("contour"))
+                return "contour";
+            if (lower.contains("konsole"))
+                return "konsole";
+            if (lower.startsWith("xterm"))
+                return "xterm";
+            if (lower.equals("linux"))
+                return "linux-console";
+        }
+
+        return "unknown";
+    }
+
+    private boolean isJetBrains() {
+        return terminalEmulator != null &&
+                (terminalEmulator.contains("JetBrains") || terminalEmulator.contains("JediTerm"));
+    }
+
+    private boolean isWindowsTerminal() {
+        if (wtSession != null || wtProfileId != null) {
+            return true;
+        }
+        return detectWindowsTerminalByRegistry();
+    }
+
+    boolean isInMultiplexer() {
+        if (inTmux || inScreen)
+            return true;
+        if (term == null)
+            return false;
+        String lower = term.toLowerCase();
+        return lower.startsWith("tmux") || lower.startsWith("screen");
+    }
+
+    // ==================== Color Depth Detection ====================
+
+    private boolean detectTrueColor() {
+        if (colorterm != null) {
+            String lower = colorterm.toLowerCase();
+            if ("truecolor".equals(lower) || "24bit".equals(lower))
+                return true;
+        }
+        if (term != null) {
+            String lower = term.toLowerCase();
+            if (lower.contains("truecolor") || lower.contains("24bit") || lower.contains("direct"))
+                return true;
+        }
+        return isKnownTrueColorTerminal();
+    }
+
+    private boolean detect256Colors() {
+        if (term != null) {
+            String lower = term.toLowerCase();
+            if (lower.contains("256color") || lower.contains("256-color"))
+                return true;
+        }
+        return isKnown256ColorTerminal();
+    }
+
+    private boolean isKnownTrueColorTerminal() {
+        switch (terminalName) {
+            case "kitty":
+            case "ghostty":
+            case "wezterm":
+            case "iterm2":
+            case "alacritty":
+            case "vscode":
+            case "windows-terminal":
+            case "foot":
+            case "contour":
+            case "konsole":
+            case "hyper":
+            case "tabby":
+            case "mintty":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private boolean isKnown256ColorTerminal() {
+        switch (terminalName) {
+            case "xterm":
+            case "apple-terminal":
+            case "jetbrains":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    // ==================== Image Protocol Detection ====================
+
+    private ImageProtocol detectImageProtocol() {
+        boolean inMux = isInMultiplexer();
+
+        if (ghosttyResourcesDir != null) {
+            return inMux ? ImageProtocol.SIXEL : ImageProtocol.KITTY;
+        }
+        if (kittyWindowId != null) {
+            return inMux ? ImageProtocol.NONE : ImageProtocol.KITTY;
+        }
+        if (itermSessionId != null || weztermPane != null) {
+            return ImageProtocol.ITERM2;
+        }
+
+        ImageProtocol fromName = imageProtocolForTerminal(terminalName);
+        if (fromName != ImageProtocol.NONE) {
+            if (inMux && fromName == ImageProtocol.KITTY) {
+                return multiplexerFallback(terminalName);
+            }
+            return fromName;
+        }
+
+        if (term != null) {
+            return imageProtocolFromTermType(term);
+        }
+
+        return ImageProtocol.NONE;
+    }
+
+    private static ImageProtocol imageProtocolForTerminal(String name) {
+        switch (name) {
+            case "kitty":
+            case "ghostty":
+            case "konsole":
+                return ImageProtocol.KITTY;
+            case "iterm2":
+            case "wezterm":
+            case "mintty":
+            case "vscode":
+            case "tabby":
+            case "hyper":
+                return ImageProtocol.ITERM2;
+            case "foot":
+            case "contour":
+            case "windows-terminal":
+                return ImageProtocol.SIXEL;
+            default:
+                return ImageProtocol.NONE;
+        }
+    }
+
+    private static ImageProtocol multiplexerFallback(String name) {
+        switch (name) {
+            case "ghostty":
+            case "konsole":
+                return ImageProtocol.SIXEL;
+            default:
+                return ImageProtocol.NONE;
+        }
+    }
+
+    private static ImageProtocol imageProtocolFromTermType(String termType) {
+        String lower = termType.toLowerCase();
+        if (lower.contains("kitty") || lower.contains("ghostty") || lower.contains("konsole"))
+            return ImageProtocol.KITTY;
+        if (lower.contains("iterm") || lower.contains("wezterm") || lower.contains("mintty") ||
+                lower.contains("vscode") || lower.contains("tabby") || lower.contains("hyper"))
+            return ImageProtocol.ITERM2;
+        if (lower.contains("mlterm") || lower.contains("foot") || lower.contains("contour") ||
+                lower.contains("yaft") || lower.contains("ctx") || lower.contains("darktile"))
+            return ImageProtocol.SIXEL;
+        return ImageProtocol.NONE;
+    }
+
+    // ==================== Theme Detection ====================
+
+    private TerminalTheme detectTheme() {
+        if (colorFgBg != null) {
+            String[] parts = colorFgBg.split(";");
+            if (parts.length >= 2) {
+                try {
+                    int bg = Integer.parseInt(parts[parts.length - 1].trim());
+                    boolean isDark = bg < 7 || bg == 8;
+                    return isDark ? TerminalTheme.DARK : TerminalTheme.LIGHT;
+                } catch (NumberFormatException ignored) {
+                }
+            }
+        }
+        if (appleInterfaceStyle != null) {
+            return "Dark".equalsIgnoreCase(appleInterfaceStyle)
+                    ? TerminalTheme.DARK
+                    : TerminalTheme.LIGHT;
+        }
+        return TerminalTheme.UNKNOWN;
+    }
+
+    /**
+     * Detect theme using platform-specific checks (subprocess/file I/O).
+     * Called by detectFull() when fast env-var detection returns UNKNOWN.
+     */
+    static TerminalTheme detectPlatformTheme() {
+        String osName = System.getProperty("os.name", "").toLowerCase();
+        try {
+            if (osName.contains("mac")) {
+                return detectMacOsTheme();
+            } else if (osName.contains("windows")) {
+                return detectWindowsTheme();
+            } else {
+                return detectLinuxDesktopTheme();
+            }
+        } catch (Exception ignored) {
+            return TerminalTheme.UNKNOWN;
+        }
+    }
+
+    private static TerminalTheme detectMacOsTheme() {
+        String result = execCommand("defaults", "read", "-g", "AppleInterfaceStyle");
+        if (result != null && result.trim().toLowerCase().contains("dark")) {
+            return TerminalTheme.DARK;
+        }
+        if (result != null) {
+            return TerminalTheme.LIGHT;
+        }
+        // "defaults read" exits non-zero when key doesn't exist (light mode)
+        return TerminalTheme.LIGHT;
+    }
+
+    private static TerminalTheme detectWindowsTheme() {
+        String value = regQuery(
+                "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+                "AppsUseLightTheme");
+        if (value != null) {
+            return "0".equals(value.trim()) ? TerminalTheme.DARK : TerminalTheme.LIGHT;
+        }
+        return TerminalTheme.UNKNOWN;
+    }
+
+    private static TerminalTheme detectLinuxDesktopTheme() {
+        // GNOME / freedesktop color-scheme
+        String result = execCommand("gsettings", "get",
+                "org.gnome.desktop.interface", "color-scheme");
+        if (result != null) {
+            String lower = result.trim().toLowerCase();
+            if (lower.contains("dark"))
+                return TerminalTheme.DARK;
+            if (lower.contains("light") || lower.contains("default"))
+                return TerminalTheme.LIGHT;
+        }
+        // KDE Plasma
+        result = execCommand("kreadconfig5", "--group", "General",
+                "--key", "ColorScheme");
+        if (result != null) {
+            String lower = result.trim().toLowerCase();
+            if (lower.contains("dark"))
+                return TerminalTheme.DARK;
+            if (lower.contains("light") || !lower.isEmpty())
+                return TerminalTheme.LIGHT;
+        }
+        return TerminalTheme.UNKNOWN;
+    }
+
+    private static String execCommand(String... cmd) {
+        Process process = null;
+        try {
+            process = new ProcessBuilder(cmd)
+                    .redirectErrorStream(true).start();
+            byte[] buf = new byte[1024];
+            StringBuilder sb = new StringBuilder();
+            int n;
+            while ((n = process.getInputStream().read(buf)) != -1) {
+                sb.append(new String(buf, 0, n));
+            }
+            process.waitFor();
+            if (process.exitValue() != 0)
+                return null;
+            return sb.toString();
+        } catch (Exception ignored) {
+            return null;
+        } finally {
+            if (process != null)
+                process.destroy();
+        }
+    }
+
+    // ==================== Windows Terminal Registry Detection ====================
+
+    private static boolean detectWindowsTerminalByRegistry() {
+        if (!System.getProperty("os.name", "").toLowerCase().contains("windows")) {
+            return false;
+        }
+        try {
+            String delegation = regQuery("HKCU\\Console\\%%Startup", "DelegationTerminal");
+            if (delegation == null)
+                return false;
+            String lower = delegation.toLowerCase();
+            if (lower.contains("{2eaca947-7f5f-4cfa-ba87-8f7fbeefbe69}") ||
+                    lower.contains("{e12cff52-a866-4c77-9a90-f570a7aa2c6b}"))
+                return true;
+            if (lower.contains("{00000000-0000-0000-0000-000000000000}"))
+                return isWindowsTerminalInstalled();
+            return false;
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    private static boolean isWindowsTerminalInstalled() {
+        String path = regQuery(
+                "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\wt.exe", "Path");
+        return path != null && !path.trim().isEmpty();
+    }
+
+    private static String regQuery(String key, String valueName) {
+        Process process = null;
+        try {
+            process = new ProcessBuilder("reg", "query", key, "/v", valueName)
+                    .redirectErrorStream(true).start();
+            byte[] buf = new byte[1024];
+            StringBuilder sb = new StringBuilder();
+            int n;
+            while ((n = process.getInputStream().read(buf)) != -1) {
+                sb.append(new String(buf, 0, n));
+            }
+            process.waitFor();
+            if (process.exitValue() != 0)
+                return null;
+            for (String line : sb.toString().split("\\r?\\n")) {
+                int idx = line.indexOf("REG_SZ");
+                if (idx >= 0)
+                    return line.substring(idx + 6).trim();
+            }
+            return null;
+        } catch (Exception ignored) {
+            return null;
+        } finally {
+            if (process != null)
+                process.destroy();
+        }
+    }
+}

--- a/terminal-detect/src/main/java/org/aesh/terminal/detect/TerminalTheme.java
+++ b/terminal-detect/src/main/java/org/aesh/terminal/detect/TerminalTheme.java
@@ -17,58 +17,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.aesh.terminal.utils;
+package org.aesh.terminal.detect;
 
 /**
- * Represents the detected terminal background theme (light or dark).
- * <p>
- * This is useful for selecting appropriate foreground colors that will
- * be readable against the terminal's background color.
- *
- * @author <a href="mailto:spederse@redhat.com">Ståle W. Pedersen</a>
+ * Terminal background theme: dark, light, or unknown.
  */
 public enum TerminalTheme {
-
-    /**
-     * Dark background theme (e.g., black, dark gray, dark blue background).
-     * Light foreground colors work best with this theme.
-     */
     DARK,
-
-    /**
-     * Light background theme (e.g., white, light gray background).
-     * Dark foreground colors work best with this theme.
-     */
     LIGHT,
-
-    /**
-     * Theme could not be determined.
-     * Applications should fall back to a safe default (typically assuming dark theme).
-     */
     UNKNOWN;
 
-    /**
-     * Check if this is a dark theme.
-     *
-     * @return true if the theme is dark or unknown (safe default)
-     */
     public boolean isDark() {
         return this == DARK || this == UNKNOWN;
     }
 
-    /**
-     * Check if this is a light theme.
-     *
-     * @return true if the theme is explicitly light
-     */
     public boolean isLight() {
         return this == LIGHT;
     }
 
     /**
      * Determine theme from RGB background color values.
-     * Uses the perceived luminance formula to determine if the background
-     * is light or dark.
+     * Uses the perceived luminance formula (ITU-R BT.601).
      *
      * @param red red component (0-255)
      * @param green green component (0-255)
@@ -76,7 +45,6 @@ public enum TerminalTheme {
      * @return LIGHT if luminance > 128, DARK otherwise
      */
     public static TerminalTheme fromRGB(int red, int green, int blue) {
-        // Use perceived luminance formula: 0.299*R + 0.587*G + 0.114*B
         double luminance = 0.299 * red + 0.587 * green + 0.114 * blue;
         return luminance > 128 ? LIGHT : DARK;
     }

--- a/terminal-detect/src/test/java/org/aesh/terminal/detect/DetectExample.java
+++ b/terminal-detect/src/test/java/org/aesh/terminal/detect/DetectExample.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aesh.terminal.detect;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class DetectExample {
+
+    public static void main(String[] args) throws Exception {
+        long start = System.nanoTime();
+        TerminalCapabilities caps = TerminalCapabilities.detect();
+        long elapsed = System.nanoTime() - start;
+
+        System.out.println("--- detect() (env vars only) ---");
+        System.out.println("Terminal:       " + caps.terminalName());
+        System.out.println("True color:     " + caps.supportsTrueColor());
+        System.out.println("256 colors:     " + caps.supports256Colors());
+        System.out.println("Image protocol: " + caps.imageProtocol());
+        System.out.println("Theme:          " + caps.theme());
+        System.out.printf("Detection time:  %.3f ms%n%n", elapsed / 1_000_000.0);
+
+        start = System.nanoTime();
+        TerminalCapabilities async = TerminalCapabilities.detectAsync();
+        long returnTime = System.nanoTime() - start;
+        System.out.printf("--- detectAsync() (returned in %.3f ms) ---%n", returnTime / 1_000_000.0);
+
+        async.awaitColors(2, TimeUnit.SECONDS);
+        elapsed = System.nanoTime() - start;
+
+        System.out.println("Theme:          " + async.theme());
+        System.out.println("256 colors:     " + async.supports256Colors());
+        System.out.println("Foreground:     " + formatRGB(async.foregroundRGB()));
+        System.out.println("Background:     " + formatRGB(async.backgroundRGB()));
+
+        Map<Integer, int[]> palette = async.paletteColors();
+        if (!palette.isEmpty()) {
+            System.out.println("Palette colors:");
+            for (Map.Entry<Integer, int[]> entry : palette.entrySet()) {
+                System.out.printf("  %2d: %s%n", entry.getKey(), formatRGB(entry.getValue()));
+            }
+        }
+
+        System.out.printf("Total time:      %.3f ms%n", elapsed / 1_000_000.0);
+    }
+
+    private static String formatRGB(int[] rgb) {
+        if (rgb == null)
+            return "null";
+        return "[" + rgb[0] + ", " + rgb[1] + ", " + rgb[2] + "]";
+    }
+}

--- a/terminal-detect/src/test/java/org/aesh/terminal/detect/TerminalCapabilitiesTest.java
+++ b/terminal-detect/src/test/java/org/aesh/terminal/detect/TerminalCapabilitiesTest.java
@@ -1,0 +1,73 @@
+package org.aesh.terminal.detect;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class TerminalCapabilitiesTest {
+
+    @Test
+    public void testDetectReturnsNonNull() {
+        TerminalCapabilities caps = TerminalCapabilities.detect();
+        assertNotNull(caps);
+        assertNotNull(caps.terminalName());
+        assertNotNull(caps.imageProtocol());
+        assertNotNull(caps.theme());
+    }
+
+    @Test
+    public void testDetectColorConsistency() {
+        TerminalCapabilities caps = TerminalCapabilities.detect();
+        if (caps.supportsTrueColor()) {
+            assertTrue(caps.supports256Colors());
+            assertTrue(caps.supportsColor());
+        }
+        if (caps.supports256Colors()) {
+            assertTrue(caps.supportsColor());
+        }
+    }
+
+    @Test
+    public void testSingleton() {
+        TerminalCapabilities a = TerminalCapabilities.getInstance();
+        TerminalCapabilities b = TerminalCapabilities.getInstance();
+        assertSame(a, b);
+    }
+
+    @Test
+    public void testSetInstance() {
+        TerminalCapabilities custom = TerminalCapabilities.detect();
+        TerminalCapabilities.setInstance(custom);
+        assertSame(custom, TerminalCapabilities.getInstance());
+        // Reset for other tests
+        TerminalCapabilities.setInstance(null);
+    }
+
+    @Test
+    public void testToString() {
+        TerminalCapabilities caps = TerminalCapabilities.detect();
+        String str = caps.toString();
+        assertNotNull(str);
+        assertTrue(str.contains("terminal="));
+        assertTrue(str.contains("trueColor="));
+        assertTrue(str.contains("imageProtocol="));
+    }
+
+    @Test
+    public void testPaletteColorsEmptyBeforeQuery() {
+        TerminalCapabilities caps = TerminalCapabilities.detect();
+        assertNotNull(caps.paletteColors());
+        assertTrue(caps.paletteColors().isEmpty());
+        assertNull(caps.foregroundRGB());
+        assertNull(caps.backgroundRGB());
+    }
+
+    @Test
+    public void testImageProtocolValues() {
+        assertEquals(4, ImageProtocol.values().length);
+        assertNotNull(ImageProtocol.valueOf("NONE"));
+        assertNotNull(ImageProtocol.valueOf("KITTY"));
+        assertNotNull(ImageProtocol.valueOf("ITERM2"));
+        assertNotNull(ImageProtocol.valueOf("SIXEL"));
+    }
+}

--- a/terminal-detect/src/test/java/org/aesh/terminal/detect/TerminalColorQueryTest.java
+++ b/terminal-detect/src/test/java/org/aesh/terminal/detect/TerminalColorQueryTest.java
@@ -1,0 +1,134 @@
+package org.aesh.terminal.detect;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class TerminalColorQueryTest {
+
+    @Test
+    public void testParseOscColorResponse_4DigitHex() {
+        String response = "\033]11;rgb:1c1c/1c1c/1c1c\007";
+        int[] rgb = TerminalColorQuery.parseOscColorResponse(response, 11, -1);
+        assertNotNull(rgb);
+        assertEquals(28, rgb[0]);
+        assertEquals(28, rgb[1]);
+        assertEquals(28, rgb[2]);
+    }
+
+    @Test
+    public void testParseOscColorResponse_2DigitHex() {
+        String response = "\033]10;rgb:ff/80/00\007";
+        int[] rgb = TerminalColorQuery.parseOscColorResponse(response, 10, -1);
+        assertNotNull(rgb);
+        assertEquals(255, rgb[0]);
+        assertEquals(128, rgb[1]);
+        assertEquals(0, rgb[2]);
+    }
+
+    @Test
+    public void testParseOscColorResponse_WithPaletteIndex() {
+        String response = "\033]4;1;rgb:cc00/0000/0000\007";
+        int[] rgb = TerminalColorQuery.parseOscColorResponse(response, 4, 1);
+        assertNotNull(rgb);
+        assertEquals(204, rgb[0]);
+        assertEquals(0, rgb[1]);
+        assertEquals(0, rgb[2]);
+    }
+
+    @Test
+    public void testParseOscColorResponse_WrongCode() {
+        String response = "\033]11;rgb:ff/ff/ff\007";
+        assertNull(TerminalColorQuery.parseOscColorResponse(response, 10, -1));
+    }
+
+    @Test
+    public void testParseOscColorResponse_WrongPaletteIndex() {
+        String response = "\033]4;2;rgb:ff/ff/ff\007";
+        assertNull(TerminalColorQuery.parseOscColorResponse(response, 4, 1));
+    }
+
+    @Test
+    public void testParseOscColorResponse_StTerminator() {
+        String response = "\033]11;rgb:0000/8080/ffff\033\\";
+        int[] rgb = TerminalColorQuery.parseOscColorResponse(response, 11, -1);
+        assertNotNull(rgb);
+        assertEquals(0, rgb[0]);
+        assertEquals(128, rgb[1]);
+        assertEquals(255, rgb[2]);
+    }
+
+    @Test
+    public void testParseOscColorResponse_MultipleResponses() {
+        String response = "\033]10;rgb:cdcd/d6d6/f4f4\007\033]11;rgb:1e1e/2e2e/4e4e\007";
+        int[] fg = TerminalColorQuery.parseOscColorResponse(response, 10, -1);
+        int[] bg = TerminalColorQuery.parseOscColorResponse(response, 11, -1);
+        assertNotNull(fg);
+        assertNotNull(bg);
+        assertEquals(205, fg[0]);
+        assertEquals(30, bg[0]);
+    }
+
+    @Test
+    public void testParseOscColorResponse_Null() {
+        assertNull(TerminalColorQuery.parseOscColorResponse(null, 11, -1));
+    }
+
+    @Test
+    public void testParseOscColorResponse_TooShort() {
+        assertNull(TerminalColorQuery.parseOscColorResponse("short", 11, -1));
+    }
+
+    @Test
+    public void testParseOscColorResponse_1DigitHex() {
+        String response = "\033]10;rgb:F/8/0\007";
+        int[] rgb = TerminalColorQuery.parseOscColorResponse(response, 10, -1);
+        assertNotNull(rgb);
+        assertEquals(255, rgb[0]);
+        assertEquals(136, rgb[1]);
+        assertEquals(0, rgb[2]);
+    }
+
+    @Test
+    public void testParseDA1Response_WithSixel() {
+        // VT340-like response: class 63, features 1;2;4;6;8;9;15
+        String response = "\033[?63;1;2;4;6;8;9;15c";
+        TerminalColorQuery result = new TerminalColorQuery();
+        TerminalColorQuery.parseDA1Response(response, result);
+        assertEquals(63, result.da1DeviceClass);
+        assertTrue(result.supportsSixel);
+        assertTrue(result.da1Features.contains(4));
+    }
+
+    @Test
+    public void testParseDA1Response_WithoutSixel() {
+        // Basic VT100: class 1, feature 2
+        String response = "\033[?1;2c";
+        TerminalColorQuery result = new TerminalColorQuery();
+        TerminalColorQuery.parseDA1Response(response, result);
+        assertEquals(1, result.da1DeviceClass);
+        assertFalse(result.supportsSixel);
+        assertFalse(result.da1Features.contains(4));
+    }
+
+    @Test
+    public void testParseDA1Response_NoResponse() {
+        TerminalColorQuery result = new TerminalColorQuery();
+        TerminalColorQuery.parseDA1Response("some garbage", result);
+        assertEquals(-1, result.da1DeviceClass);
+        assertFalse(result.supportsSixel);
+    }
+
+    @Test
+    public void testParseDA1Response_MixedWithOsc() {
+        String response = "\033[?62;4c\033]11;rgb:1c1c/1c1c/1c1c\007";
+        TerminalColorQuery result = new TerminalColorQuery();
+        TerminalColorQuery.parseDA1Response(response, result);
+        assertEquals(62, result.da1DeviceClass);
+        assertTrue(result.supportsSixel);
+        // OSC still parseable
+        int[] bg = TerminalColorQuery.parseOscColorResponse(response, 11, -1);
+        assertNotNull(bg);
+        assertEquals(28, bg[0]);
+    }
+}

--- a/terminal-detect/src/test/java/org/aesh/terminal/detect/TerminalThemeTest.java
+++ b/terminal-detect/src/test/java/org/aesh/terminal/detect/TerminalThemeTest.java
@@ -17,7 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.aesh.terminal.utils;
+package org.aesh.terminal.detect;
 
 import static org.junit.Assert.*;
 

--- a/terminal-tty/src/main/java/org/aesh/terminal/tty/PlatformThemeDetector.java
+++ b/terminal-tty/src/main/java/org/aesh/terminal/tty/PlatformThemeDetector.java
@@ -31,12 +31,12 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.aesh.terminal.detect.TerminalTheme;
 import org.aesh.terminal.tty.utils.ColorUtils;
 import org.aesh.terminal.tty.utils.ProcessHelper;
 import org.aesh.terminal.tty.utils.ThemeNameClassifier;
 import org.aesh.terminal.utils.LoggerUtil;
 import org.aesh.terminal.utils.TerminalEnvironment;
-import org.aesh.terminal.utils.TerminalTheme;
 
 /**
  * Detects the terminal theme by reading platform-specific configuration files

--- a/terminal-tty/src/main/java/org/aesh/terminal/tty/TerminalColorDetector.java
+++ b/terminal-tty/src/main/java/org/aesh/terminal/tty/TerminalColorDetector.java
@@ -33,6 +33,7 @@ import org.aesh.terminal.Connection;
 import org.aesh.terminal.Device;
 import org.aesh.terminal.Terminal;
 import org.aesh.terminal.TerminalFeatures;
+import org.aesh.terminal.detect.TerminalTheme;
 import org.aesh.terminal.tty.utils.ColorUtils;
 import org.aesh.terminal.utils.ANSI;
 import org.aesh.terminal.utils.CodePointUtils;
@@ -40,7 +41,6 @@ import org.aesh.terminal.utils.ColorDepth;
 import org.aesh.terminal.utils.LoggerUtil;
 import org.aesh.terminal.utils.TerminalColorCapability;
 import org.aesh.terminal.utils.TerminalEnvironment;
-import org.aesh.terminal.utils.TerminalTheme;
 
 /**
  * Utility class to detect terminal color capabilities.

--- a/terminal-tty/src/main/java/org/aesh/terminal/tty/utils/ThemeNameClassifier.java
+++ b/terminal-tty/src/main/java/org/aesh/terminal/tty/utils/ThemeNameClassifier.java
@@ -19,7 +19,7 @@
  */
 package org.aesh.terminal.tty.utils;
 
-import org.aesh.terminal.utils.TerminalTheme;
+import org.aesh.terminal.detect.TerminalTheme;
 
 /**
  * Classifies theme/color-scheme names as DARK or LIGHT based on known keywords.


### PR DESCRIPTION
Zero-dependency module for detecting terminal capabilities via environment variables, heuristics, and optional async OSC queries.

API:
  TerminalCapabilities caps = TerminalCapabilities.detect();      // ~1ms
  TerminalCapabilities caps = TerminalCapabilities.detectAsync(); // background color query
  caps.supportsTrueColor() / supports256Colors()
  caps.imageProtocol()      // NONE, KITTY, ITERM2, SIXEL
  caps.theme()              // DARK, LIGHT, UNKNOWN
  caps.foregroundRGB() / backgroundRGB() / paletteColors()
  caps.red() / green() / blue() / ... / brightWhite()

Singleton support for reuse across modules:
  TerminalCapabilities.setInstance(caps);  // set early in startup
  TerminalCapabilities.getInstance();     // reuse later

Integration with terminal-api:
  - ImageProtocol and TerminalTheme enums owned by terminal-detect
  - terminal-api depends on terminal-detect and reuses shared enums
  - TerminalEnvironment delegates color depth and Windows Terminal detection to TerminalCapabilities singleton