### PR TITLE
Add table-driven ANSI/VT escape sequence parser

### DIFF
--- a/benchmark/src/main/java/org/aesh/readline/BufferBenchmark.java
+++ b/benchmark/src/main/java/org/aesh/readline/BufferBenchmark.java
@@ -21,6 +21,8 @@ package org.aesh.readline;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+
+import org.aesh.readline.prompt.Prompt;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;

--- a/benchmark/src/main/java/org/aesh/readline/TuiOutputBenchmark.java
+++ b/benchmark/src/main/java/org/aesh/readline/TuiOutputBenchmark.java
@@ -27,6 +27,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
+import org.aesh.readline.prompt.Prompt;
+
 import org.aesh.terminal.Attributes;
 import org.aesh.terminal.BaseDevice;
 import org.aesh.terminal.Connection;

--- a/benchmark/src/main/java/org/aesh/readline/benchmark/EventDecoderBenchmark.java
+++ b/benchmark/src/main/java/org/aesh/readline/benchmark/EventDecoderBenchmark.java
@@ -1,0 +1,172 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aesh.readline.benchmark;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import org.aesh.terminal.EventDecoder;
+import org.aesh.terminal.tty.Signal;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Benchmarks for EventDecoder signal extraction and DSR filtering.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(2)
+@State(Scope.Thread)
+public class EventDecoderBenchmark {
+
+    // Normal text — no signals, no ESC (fast path)
+    private static final int[] TEXT_SHORT = "hello".codePoints().toArray();
+    private static final int[] TEXT_LINE = "The quick brown fox jumps over the lazy dog".codePoints().toArray();
+
+    // Text with embedded signal (Ctrl+C = 3)
+    private static final int[] TEXT_WITH_SIGNAL = "hel\003lo".codePoints().toArray();
+
+    // Multiple signals in one chunk
+    private static final int[] MULTIPLE_SIGNALS = "a\003b\004c\032d".codePoints().toArray();
+
+    // Escape sequence — triggers DSR filter scan
+    private static final int[] ESCAPE_SEQUENCE = { 27, 91, 65 }; // ESC [ A
+
+    // Theme DSR sequence: CSI ? 997 ; 1 n
+    private static final int[] THEME_DSR = { 27, 91, 63, 57, 57, 55, 59, 49, 110 };
+
+    // Mixed: text + escape + text
+    private static final int[] MIXED;
+    static {
+        String s = "hello\033[Aworld\033[B";
+        MIXED = s.codePoints().toArray();
+    }
+
+    private EventDecoder decoder;
+    private EventDecoder decoderWithDsr;
+    private int inputCount;
+    private int signalCount;
+
+    @Setup(Level.Trial)
+    public void setup() {
+    }
+
+    @Setup(Level.Invocation)
+    public void resetDecoder() {
+        inputCount = 0;
+        signalCount = 0;
+
+        decoder = new EventDecoder();
+        decoder.setSignalHandler(s -> signalCount++);
+        decoder.setInputHandler(input -> inputCount++);
+
+        decoderWithDsr = new EventDecoder();
+        decoderWithDsr.setSignalHandler(s -> signalCount++);
+        decoderWithDsr.setInputHandler(input -> inputCount++);
+        decoderWithDsr.setThemeChangeHandler(theme -> {});
+    }
+
+    // ========== No signals (fast path) ==========
+
+    @Benchmark
+    public void textNoSignals(Blackhole bh) {
+        decoder.accept(TEXT_SHORT);
+        bh.consume(inputCount);
+    }
+
+    @Benchmark
+    public void textLineNoSignals(Blackhole bh) {
+        decoder.accept(TEXT_LINE);
+        bh.consume(inputCount);
+    }
+
+    // ========== With signals ==========
+
+    @Benchmark
+    public void textWithSignal(Blackhole bh) {
+        decoder.accept(TEXT_WITH_SIGNAL);
+        bh.consume(inputCount + signalCount);
+    }
+
+    @Benchmark
+    public void multipleSignals(Blackhole bh) {
+        decoder.accept(MULTIPLE_SIGNALS);
+        bh.consume(inputCount + signalCount);
+    }
+
+    // ========== DSR filter ==========
+
+    @Benchmark
+    public void textWithDsrFilter(Blackhole bh) {
+        // Normal text through DSR filter — should hit fast path (no ESC)
+        decoderWithDsr.accept(TEXT_SHORT);
+        bh.consume(inputCount);
+    }
+
+    @Benchmark
+    public void escapeSequenceWithDsrFilter(Blackhole bh) {
+        // ESC sequence through DSR filter — triggers state machine
+        decoderWithDsr.accept(ESCAPE_SEQUENCE);
+        bh.consume(inputCount);
+    }
+
+    @Benchmark
+    public void themeDsrSequence(Blackhole bh) {
+        // Full theme DSR sequence — should be consumed by filter
+        decoderWithDsr.accept(THEME_DSR);
+        bh.consume(inputCount);
+    }
+
+    // ========== Mixed ==========
+
+    @Benchmark
+    public void mixedInput(Blackhole bh) {
+        decoder.accept(MIXED);
+        bh.consume(inputCount);
+    }
+
+    @Benchmark
+    public void mixedInputWithDsr(Blackhole bh) {
+        decoderWithDsr.accept(MIXED);
+        bh.consume(inputCount);
+    }
+
+    // ========== Throughput ==========
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void textThroughput(Blackhole bh) {
+        decoder.accept(TEXT_LINE);
+        bh.consume(inputCount);
+    }
+}

--- a/benchmark/src/main/java/org/aesh/readline/benchmark/KeyMappingTrieBenchmark.java
+++ b/benchmark/src/main/java/org/aesh/readline/benchmark/KeyMappingTrieBenchmark.java
@@ -1,0 +1,142 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aesh.readline.benchmark;
+
+import java.util.concurrent.TimeUnit;
+
+import org.aesh.readline.action.KeyMappingTrie;
+import org.aesh.terminal.Key;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Benchmarks for KeyMappingTrie lookup performance.
+ * <p>
+ * HotSpot's escape analysis eliminates MatchResult heap allocation
+ * on the hot path, so the object-returning API is effectively
+ * zero-allocation. A packed-long alternative was benchmarked and
+ * found to be slower due to HashMap overhead in the pack/unpack path.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(2)
+@State(Scope.Thread)
+public class KeyMappingTrieBenchmark {
+
+    // Single-byte inputs
+    private static final int CHAR_A = 'a';
+    private static final int ESC = 27;
+
+    // Multi-byte sequences
+    private static final int[] ARROW_UP = { 27, 91, 65 };
+    private static final int[] F12 = { 27, 91, 50, 52, 126 };
+    private static final int[] UNKNOWN_CSI = { 27, 91, 60, 48, 59, 53, 59, 51, 77 }; // mouse SGR
+
+    // Buffer with offset (simulates ActionDecoder's offset tracking)
+    private static final int[] PADDED_ARROW_UP = { 0, 0, 0, 27, 91, 65, 0, 0 };
+    private static final int PADDED_OFFSET = 3;
+    private static final int PADDED_LENGTH = 3;
+
+    private KeyMappingTrie trie;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        trie = new KeyMappingTrie();
+        trie.build(Key.values());
+    }
+
+    // ========== Single-byte lookups ==========
+
+    @Benchmark
+    public void singleByteChar(Blackhole bh) {
+        KeyMappingTrie.MatchResult r = trie.matchSingleByte(CHAR_A);
+        bh.consume(r.action);
+        bh.consume(r.hasPrefix);
+    }
+
+    @Benchmark
+    public void singleByteEsc(Blackhole bh) {
+        KeyMappingTrie.MatchResult r = trie.matchSingleByte(ESC);
+        bh.consume(r.action);
+        bh.consume(r.hasPrefix);
+    }
+
+    // ========== Multi-byte lookups ==========
+
+    @Benchmark
+    public void arrowUp(Blackhole bh) {
+        KeyMappingTrie.MatchResult r = trie.match(ARROW_UP);
+        bh.consume(r.action);
+        bh.consume(r.hasPrefix);
+    }
+
+    @Benchmark
+    public void arrowUpWithOffset(Blackhole bh) {
+        KeyMappingTrie.MatchResult r = trie.match(PADDED_ARROW_UP, PADDED_OFFSET, PADDED_LENGTH);
+        bh.consume(r.action);
+        bh.consume(r.hasPrefix);
+    }
+
+    @Benchmark
+    public void f12(Blackhole bh) {
+        KeyMappingTrie.MatchResult r = trie.match(F12);
+        bh.consume(r.action);
+        bh.consume(r.hasPrefix);
+    }
+
+    // ========== Unknown sequence ==========
+
+    @Benchmark
+    public void unknownCsi(Blackhole bh) {
+        KeyMappingTrie.MatchResult r = trie.match(UNKNOWN_CSI);
+        bh.consume(r.action);
+        bh.consume(r.hasPrefix);
+    }
+
+    // ========== Throughput ==========
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void singleByteThroughput(Blackhole bh) {
+        KeyMappingTrie.MatchResult r = trie.matchSingleByte(CHAR_A);
+        bh.consume(r);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void arrowKeyThroughput(Blackhole bh) {
+        KeyMappingTrie.MatchResult r = trie.match(ARROW_UP);
+        bh.consume(r);
+    }
+}

--- a/benchmark/src/main/java/org/aesh/readline/benchmark/VtParserBenchmark.java
+++ b/benchmark/src/main/java/org/aesh/readline/benchmark/VtParserBenchmark.java
@@ -1,0 +1,249 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aesh.readline.benchmark;
+
+import java.util.concurrent.TimeUnit;
+
+import org.aesh.terminal.parser.VtHandler;
+import org.aesh.terminal.parser.VtParser;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Benchmarks for VtParser escape sequence classification performance.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(2)
+@State(Scope.Thread)
+public class VtParserBenchmark {
+
+    // Printable text — the hot path (95%+ of input)
+    private static final byte[] PRINTABLE_SHORT = "hello".getBytes();
+    private static final byte[] PRINTABLE_LINE = "The quick brown fox jumps over the lazy dog".getBytes();
+
+    // CSI sequences
+    private static final byte[] CSI_ARROW_UP = "\033[A".getBytes();
+    private static final byte[] CSI_CURSOR_POS = "\033[10;20H".getBytes();
+    private static final byte[] CSI_SGR_COLOR = "\033[38;2;255;128;0m".getBytes();
+    private static final byte[] CSI_PRIVATE = "\033[?1049h".getBytes();
+    private static final byte[] CSI_DA1_RESPONSE = "\033[?65;1;9c".getBytes();
+
+    // SGR mouse event
+    private static final byte[] MOUSE_SGR = "\033[<0;42;17M".getBytes();
+
+    // OSC sequences
+    private static final byte[] OSC_TITLE = "\033]0;My Terminal Title\007".getBytes();
+    private static final byte[] OSC_COLOR = "\033]10;rgb:ffff/8080/0000\007".getBytes();
+
+    // Mixed input — realistic terminal session
+    private static final byte[] MIXED_INPUT;
+    static {
+        StringBuilder sb = new StringBuilder();
+        sb.append("ls -la /tmp");           // typing
+        sb.append("\033[A");                // arrow up
+        sb.append("\033[A");                // arrow up
+        sb.append("\033[B");                // arrow down
+        sb.append("grep foo bar.txt");      // typing
+        sb.append("\r");                    // enter
+        sb.append("\033[?1049h");           // alt screen on
+        sb.append("\033[2J");               // clear screen
+        sb.append("\033[1;1H");             // cursor home
+        sb.append("Hello, World!");         // typing
+        sb.append("\033[?1049l");           // alt screen off
+        MIXED_INPUT = sb.toString().getBytes();
+    }
+
+    private VtParser parser;
+    private CountingHandler handler;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        handler = new CountingHandler();
+        parser = new VtParser(handler);
+    }
+
+    @Setup(Level.Invocation)
+    public void resetParser() {
+        parser.reset();
+        handler.reset();
+    }
+
+    // ========== Printable text (hot path) ==========
+
+    @Benchmark
+    public void printableShort(Blackhole bh) {
+        parser.advance(PRINTABLE_SHORT, 0, PRINTABLE_SHORT.length);
+        bh.consume(handler.printCount);
+    }
+
+    @Benchmark
+    public void printableLine(Blackhole bh) {
+        parser.advance(PRINTABLE_LINE, 0, PRINTABLE_LINE.length);
+        bh.consume(handler.printCount);
+    }
+
+    // ========== CSI sequences ==========
+
+    @Benchmark
+    public void csiArrowKey(Blackhole bh) {
+        parser.advance(CSI_ARROW_UP, 0, CSI_ARROW_UP.length);
+        bh.consume(handler.csiCount);
+    }
+
+    @Benchmark
+    public void csiCursorPosition(Blackhole bh) {
+        parser.advance(CSI_CURSOR_POS, 0, CSI_CURSOR_POS.length);
+        bh.consume(handler.csiCount);
+    }
+
+    @Benchmark
+    public void csiSgrColor(Blackhole bh) {
+        parser.advance(CSI_SGR_COLOR, 0, CSI_SGR_COLOR.length);
+        bh.consume(handler.csiCount);
+    }
+
+    @Benchmark
+    public void csiPrivateMode(Blackhole bh) {
+        parser.advance(CSI_PRIVATE, 0, CSI_PRIVATE.length);
+        bh.consume(handler.csiCount);
+    }
+
+    @Benchmark
+    public void csiDa1Response(Blackhole bh) {
+        parser.advance(CSI_DA1_RESPONSE, 0, CSI_DA1_RESPONSE.length);
+        bh.consume(handler.csiCount);
+    }
+
+    @Benchmark
+    public void mouseSgr(Blackhole bh) {
+        parser.advance(MOUSE_SGR, 0, MOUSE_SGR.length);
+        bh.consume(handler.csiCount);
+    }
+
+    // ========== OSC sequences ==========
+
+    @Benchmark
+    public void oscTitle(Blackhole bh) {
+        parser.advance(OSC_TITLE, 0, OSC_TITLE.length);
+        bh.consume(handler.oscCount);
+    }
+
+    @Benchmark
+    public void oscColorQuery(Blackhole bh) {
+        parser.advance(OSC_COLOR, 0, OSC_COLOR.length);
+        bh.consume(handler.oscCount);
+    }
+
+    // ========== Mixed input ==========
+
+    @Benchmark
+    public void mixedInput(Blackhole bh) {
+        parser.advance(MIXED_INPUT, 0, MIXED_INPUT.length);
+        bh.consume(handler.printCount + handler.csiCount + handler.oscCount);
+    }
+
+    // ========== Throughput ==========
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void printableThroughput(Blackhole bh) {
+        parser.advance(PRINTABLE_LINE, 0, PRINTABLE_LINE.length);
+        bh.consume(handler.printCount);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void mixedThroughput(Blackhole bh) {
+        parser.advance(MIXED_INPUT, 0, MIXED_INPUT.length);
+        bh.consume(handler.printCount + handler.csiCount);
+    }
+
+    // ========== Code point path ==========
+
+    private static final int[] CODEPOINT_ARROW = { 27, 91, 65 };
+    private static final int[] CODEPOINT_TEXT = "Hello".codePoints().toArray();
+
+    @Benchmark
+    public void codePointArrowKey(Blackhole bh) {
+        parser.advance(CODEPOINT_ARROW, 0, CODEPOINT_ARROW.length);
+        bh.consume(handler.csiCount);
+    }
+
+    @Benchmark
+    public void codePointText(Blackhole bh) {
+        parser.advance(CODEPOINT_TEXT, 0, CODEPOINT_TEXT.length);
+        bh.consume(handler.printCount);
+    }
+
+    /**
+     * Minimal handler that counts events without allocating.
+     */
+    static class CountingHandler implements VtHandler {
+        int printCount;
+        int csiCount;
+        int escCount;
+        int oscCount;
+        int executeCount;
+
+        void reset() {
+            printCount = 0;
+            csiCount = 0;
+            escCount = 0;
+            oscCount = 0;
+            executeCount = 0;
+        }
+
+        @Override
+        public void print(int codePoint) { printCount++; }
+
+        @Override
+        public void execute(int controlChar) { executeCount++; }
+
+        @Override
+        public void escDispatch(int finalChar, int[] intermediates, int intermediateCount) {
+            escCount++;
+        }
+
+        @Override
+        public void csiDispatch(int finalChar, int[] params, int paramCount,
+                                int[] intermediates, int intermediateCount,
+                                boolean hasSubParams) {
+            csiCount++;
+        }
+
+        @Override
+        public void oscEnd(String data) { oscCount++; }
+    }
+}

--- a/readline/src/main/java/org/aesh/readline/action/ActionDecoder.java
+++ b/readline/src/main/java/org/aesh/readline/action/ActionDecoder.java
@@ -26,18 +26,34 @@ import java.util.Queue;
 import org.aesh.readline.editing.EditMode;
 import org.aesh.terminal.Key;
 import org.aesh.terminal.KeyAction;
+import org.aesh.terminal.parser.VtHandler;
+import org.aesh.terminal.parser.VtParser;
 
 /**
  * Decodes input key sequences and maps them to corresponding actions.
+ * <p>
+ * Uses a pre-allocated buffer with offset tracking to avoid per-keystroke
+ * array allocations. The buffer grows when needed but is compacted only
+ * when the read offset exceeds half the capacity.
  *
  * @author <a href="mailto:spederse@redhat.com">Ståle W. Pedersen</a>
  */
 public class ActionDecoder {
 
+    private static final int INITIAL_CAPACITY = 128;
+
     private KeyAction[] mappings;
     private final KeyMappingTrie trie;
     private final Queue<KeyAction> actions = new LinkedList<>();
-    private int[] buffer = new int[0];
+
+    // Pre-allocated buffer with offset tracking — avoids copy on every consume
+    private int[] buffer = new int[INITIAL_CAPACITY];
+    private int bufferOffset; // read position
+    private int bufferLength; // write position (number of valid elements)
+
+    // Reusable VtParser for unknown sequence measurement
+    private final VtParser vtParser;
+    private final SequenceMeasurer sequenceMeasurer;
 
     /**
      * Creates a decoder with key mappings from the specified edit mode.
@@ -48,6 +64,8 @@ public class ActionDecoder {
         this.mappings = editMode.keys();
         this.trie = new KeyMappingTrie();
         this.trie.build(this.mappings);
+        this.sequenceMeasurer = new SequenceMeasurer();
+        this.vtParser = new VtParser(this.sequenceMeasurer);
     }
 
     /**
@@ -57,6 +75,8 @@ public class ActionDecoder {
         this.mappings = Key.values();
         this.trie = new KeyMappingTrie();
         this.trie.build(this.mappings);
+        this.sequenceMeasurer = new SequenceMeasurer();
+        this.vtParser = new VtParser(this.sequenceMeasurer);
     }
 
     /**
@@ -65,8 +85,9 @@ public class ActionDecoder {
      * @param input the array of code points to add
      */
     public void add(int[] input) {
-        buffer = Arrays.copyOf(buffer, buffer.length + input.length);
-        System.arraycopy(input, 0, buffer, buffer.length - input.length, input.length);
+        ensureCapacity(input.length);
+        System.arraycopy(input, 0, buffer, bufferLength, input.length);
+        bufferLength += input.length;
     }
 
     /**
@@ -75,8 +96,8 @@ public class ActionDecoder {
      * @param input the code point to add
      */
     public void add(int input) {
-        buffer = Arrays.copyOf(buffer, buffer.length + 1);
-        System.arraycopy(new int[] { input }, 0, buffer, buffer.length - 1, 1);
+        ensureCapacity(1);
+        buffer[bufferLength++] = input;
     }
 
     /**
@@ -86,7 +107,7 @@ public class ActionDecoder {
      */
     public KeyAction peek() {
         if (actions.isEmpty()) {
-            return parse(buffer);
+            return parse();
         } else {
             return actions.peek();
         }
@@ -108,10 +129,14 @@ public class ActionDecoder {
      */
     public KeyAction next() {
         if (actions.isEmpty()) {
-            KeyAction next = parse(buffer);
+            KeyAction next = parse();
             if (next != null) {
                 actions.add(next);
-                buffer = Arrays.copyOfRange(buffer, next.length(), buffer.length);
+                bufferOffset += next.length();
+                // Compact when the read offset exceeds half the capacity
+                if (bufferOffset > buffer.length / 2) {
+                    compact();
+                }
             }
         }
         return actions.remove();
@@ -127,14 +152,15 @@ public class ActionDecoder {
         trie.build(mappings);
     }
 
-    private KeyAction parse(int[] buffer) {
-        if (buffer.length == 0) {
+    private KeyAction parse() {
+        int available = bufferLength - bufferOffset;
+        if (available == 0) {
             return null;
         }
 
-        // Fast path: single printable character
-        if (buffer.length == 1) {
-            int code = buffer[0];
+        // Fast path: single code point
+        if (available == 1) {
+            int code = buffer[bufferOffset];
             KeyMappingTrie.MatchResult result = trie.matchSingleByte(code);
             if (result.action != null) {
                 return result.action;
@@ -142,24 +168,156 @@ public class ActionDecoder {
             if (!result.hasPrefix) {
                 return new DefaultKeyAction(code);
             }
-            // Has prefix - wait for more input
+            // Has prefix — wait for more input
             return null;
         }
 
         // Full trie lookup for multi-byte sequences
-        KeyMappingTrie.MatchResult result = trie.match(buffer);
+        KeyMappingTrie.MatchResult result = trie.match(buffer, bufferOffset, available);
 
         if (result.action != null) {
             return result.action;
         }
 
         if (result.hasPrefix) {
-            // Buffer is prefix of a longer sequence - wait for more input
+            // Buffer is prefix of a longer sequence — wait for more input
             return null;
         }
 
-        // No match and not a prefix - return single character
-        return new DefaultKeyAction(buffer[0]);
+        // No match and not a prefix — use VtParser to classify the sequence.
+        // This prevents unknown CSI/OSC/DCS sequences from leaking byte-by-byte.
+        int firstByte = buffer[bufferOffset];
+        if (firstByte == 27 && available > 1) { // starts with ESC
+            int seqLen = measureEscapeSequence(buffer, bufferOffset, available);
+            if (seqLen > 1) {
+                // Complete unrecognized sequence — consume it as one action
+                return new SequenceKeyAction(buffer, bufferOffset, seqLen);
+            }
+            if (seqLen == -1) {
+                // Incomplete sequence — wait for more input
+                return null;
+            }
+        }
+
+        // Not an escape sequence — return single character
+        return new DefaultKeyAction(firstByte);
+    }
+
+    /**
+     * Measures the length of a complete escape sequence using the reusable VtParser.
+     */
+    private int measureEscapeSequence(int[] buf, int offset, int length) {
+        sequenceMeasurer.reset();
+        vtParser.reset();
+
+        for (int i = 0; i < length; i++) {
+            vtParser.advance(buf[offset + i]);
+            if (sequenceMeasurer.complete) {
+                return i + 1;
+            }
+        }
+
+        // Sequence is not complete — need more input
+        return -1;
+    }
+
+    /**
+     * Ensures the buffer has room for additionalCount more elements.
+     */
+    private void ensureCapacity(int additionalCount) {
+        int available = bufferLength - bufferOffset;
+        int needed = available + additionalCount;
+
+        if (needed > buffer.length - bufferOffset) {
+            if (needed <= buffer.length) {
+                // Compact: shift data to front
+                compact();
+            } else {
+                // Grow: allocate bigger buffer
+                int newCapacity = Math.max(buffer.length * 2, needed);
+                int[] newBuffer = new int[newCapacity];
+                System.arraycopy(buffer, bufferOffset, newBuffer, 0, available);
+                buffer = newBuffer;
+                bufferOffset = 0;
+                bufferLength = available;
+            }
+        }
+    }
+
+    /**
+     * Compacts the buffer by shifting remaining data to the front.
+     */
+    private void compact() {
+        int available = bufferLength - bufferOffset;
+        if (bufferOffset > 0 && available > 0) {
+            System.arraycopy(buffer, bufferOffset, buffer, 0, available);
+        }
+        bufferOffset = 0;
+        bufferLength = available;
+    }
+
+    /**
+     * Reusable VtHandler that tracks whether a complete sequence was found.
+     */
+    private static class SequenceMeasurer implements VtHandler {
+        boolean complete;
+
+        void reset() {
+            complete = false;
+        }
+
+        @Override
+        public void escDispatch(int finalChar, int[] intermediates, int intermediateCount) {
+            complete = true;
+        }
+
+        @Override
+        public void csiDispatch(int finalChar, int[] params, int paramCount,
+                int[] intermediates, int intermediateCount,
+                boolean hasSubParams) {
+            complete = true;
+        }
+
+        @Override
+        public void oscEnd(String data) {
+            complete = true;
+        }
+
+        @Override
+        public void hook(int finalChar, int[] params, int paramCount,
+                int[] intermediates, int intermediateCount) {
+            complete = true;
+        }
+    }
+
+    /**
+     * A key action representing a complete but unrecognized escape sequence.
+     * This prevents unknown CSI/OSC/DCS sequences from leaking byte-by-byte
+     * into the input stream.
+     */
+    private static class SequenceKeyAction implements KeyAction {
+
+        private final int[] codePoints;
+
+        SequenceKeyAction(int[] buffer, int offset, int length) {
+            this.codePoints = new int[length];
+            System.arraycopy(buffer, offset, codePoints, 0, length);
+        }
+
+        @Override
+        public int getCodePointAt(int index) throws IndexOutOfBoundsException {
+            return codePoints[index];
+        }
+
+        @Override
+        public int length() {
+            return codePoints.length;
+        }
+
+        @Override
+        public String name() {
+            return "sequence: " + Arrays.toString(codePoints);
+        }
     }
 
     private static class DefaultKeyAction implements KeyAction {

--- a/readline/src/main/java/org/aesh/readline/action/KeyMappingTrie.java
+++ b/readline/src/main/java/org/aesh/readline/action/KeyMappingTrie.java
@@ -28,6 +28,10 @@ import org.aesh.terminal.KeyAction;
  * A trie-based data structure for efficient key sequence matching.
  * Provides O(m) lookup complexity where m is the length of the input sequence,
  * compared to O(n*m) for linear search where n is the number of mappings.
+ * <p>
+ * The single-byte fast path uses pre-computed arrays for O(1) lookup.
+ * HotSpot's escape analysis eliminates the MatchResult allocation on
+ * the hot path, making the object-returning API zero-allocation in practice.
  *
  * @author <a href="mailto:spederse@redhat.com">Ståle W. Pedersen</a>
  */
@@ -62,21 +66,14 @@ public class KeyMappingTrie {
      * Internal trie node structure.
      */
     private static class TrieNode {
-        // Sparse array for children with code points 0-255 (covers ASCII and common control chars)
+        // Sparse array for children with code points 0-255
         private final TrieNode[] children = new TrieNode[256];
         // Map for extended code points > 255
         private Map<Integer, TrieNode> extendedChildren;
         // The KeyAction at this node (if this is a terminal node)
         private KeyAction action;
-
-        boolean hasChildren() {
-            for (TrieNode child : children) {
-                if (child != null) {
-                    return true;
-                }
-            }
-            return extendedChildren != null && !extendedChildren.isEmpty();
-        }
+        // Tracked child count to avoid scanning the 256-element array
+        private int childCount;
     }
 
     /**
@@ -92,7 +89,6 @@ public class KeyMappingTrie {
                 insert(mapping);
             }
         }
-        // Pre-compute single-byte lookups for fast path
         computeSingleByteLookups();
     }
 
@@ -107,6 +103,7 @@ public class KeyMappingTrie {
         }
         root.extendedChildren = null;
         root.action = null;
+        root.childCount = 0;
     }
 
     /**
@@ -123,15 +120,12 @@ public class KeyMappingTrie {
             }
             current = child;
         }
-        // Prefer longer matches - only set if not already set or if current is longer/equal
+        // Prefer longer matches
         if (current.action == null || current.action.length() <= action.length()) {
             current.action = action;
         }
     }
 
-    /**
-     * Gets a child node for the given code point.
-     */
     private TrieNode getChild(TrieNode node, int codePoint) {
         if (codePoint >= 0 && codePoint < 256) {
             return node.children[codePoint];
@@ -141,29 +135,29 @@ public class KeyMappingTrie {
         return null;
     }
 
-    /**
-     * Sets a child node for the given code point.
-     */
     private void setChild(TrieNode node, int codePoint, TrieNode child) {
         if (codePoint >= 0 && codePoint < 256) {
+            if (node.children[codePoint] == null) {
+                node.childCount++;
+            }
             node.children[codePoint] = child;
         } else {
             if (node.extendedChildren == null) {
                 node.extendedChildren = new HashMap<>();
             }
+            if (!node.extendedChildren.containsKey(codePoint)) {
+                node.childCount++;
+            }
             node.extendedChildren.put(codePoint, child);
         }
     }
 
-    /**
-     * Pre-computes single-byte lookups for the fast path.
-     */
     private void computeSingleByteLookups() {
         for (int i = 0; i < 256; i++) {
             TrieNode child = root.children[i];
             if (child != null) {
                 singleByteLookup[i] = child.action;
-                singleByteHasPrefix[i] = child.hasChildren();
+                singleByteHasPrefix[i] = child.childCount > 0;
             }
         }
     }
@@ -183,13 +177,28 @@ public class KeyMappingTrie {
 
     /**
      * Matches the input buffer against the trie.
-     * Returns the longest matching KeyAction and whether the buffer is a prefix of longer sequences.
+     * Returns the longest matching KeyAction and whether the buffer is a prefix.
      *
      * @param buffer the input code points to match
-     * @return the match result containing the action and prefix information
+     * @return the match result
      */
     public MatchResult match(int[] buffer) {
         if (buffer == null || buffer.length == 0) {
+            return new MatchResult(null, false);
+        }
+        return match(buffer, 0, buffer.length);
+    }
+
+    /**
+     * Matches a range of the input buffer against the trie.
+     *
+     * @param buffer the input code points
+     * @param offset the start offset in the buffer
+     * @param length the number of code points to match
+     * @return the match result
+     */
+    public MatchResult match(int[] buffer, int offset, int length) {
+        if (buffer == null || length == 0) {
             return new MatchResult(null, false);
         }
 
@@ -197,24 +206,22 @@ public class KeyMappingTrie {
         KeyAction longestMatch = null;
         boolean hasPrefix = false;
 
-        for (int i = 0; i < buffer.length; i++) {
+        int end = offset + length;
+        for (int i = offset; i < end; i++) {
             int codePoint = buffer[i];
             TrieNode child = getChild(current, codePoint);
 
             if (child == null) {
-                // No more matches possible
                 break;
             }
 
             current = child;
 
-            // Track the longest complete match found so far
             if (current.action != null) {
                 longestMatch = current.action;
             }
 
-            // Check if this is a prefix of a longer sequence (at the end of buffer)
-            if (i == buffer.length - 1 && current.hasChildren()) {
+            if (i == end - 1 && current.childCount > 0) {
                 hasPrefix = true;
             }
         }

--- a/terminal-api/src/main/java/org/aesh/terminal/EventDecoder.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/EventDecoder.java
@@ -191,10 +191,12 @@ public class EventDecoder implements Consumer<int[]> {
      */
     @Override
     public void accept(int[] input) {
-        if (signalHandler != null) {
-            int index = 0;
-            while (index < input.length) {
-                int val = input[index];
+        if (signalHandler != null && input.length > 0) {
+            // Single-pass signal extraction: scan once, dispatch signals and
+            // input segments without re-scanning the remainder.
+            int segmentStart = 0;
+            for (int i = 0; i < input.length; i++) {
+                int val = input[i];
                 Signal event = null;
                 if (val == intr) {
                     event = Signal.INT;
@@ -204,23 +206,25 @@ public class EventDecoder implements Consumer<int[]> {
                     event = Signal.EOF;
                 }
                 if (event != null) {
-                    if (signalHandler != null) {
-                        if (inputHandler != null) {
-                            int[] a = new int[index];
-                            if (index > 0) {
-                                System.arraycopy(input, 0, a, 0, index);
-                                inputHandler.accept(a);
-                            }
-                        }
-                        signalHandler.accept(event);
-                        int[] a = new int[input.length - index - 1];
-                        System.arraycopy(input, index + 1, a, 0, a.length);
-                        input = a;
-                        index = 0;
-                        continue;
+                    // Send any input before this signal to the input handler
+                    if (i > segmentStart && inputHandler != null) {
+                        int[] segment = new int[i - segmentStart];
+                        System.arraycopy(input, segmentStart, segment, 0, segment.length);
+                        inputHandler.accept(segment);
                     }
+                    signalHandler.accept(event);
+                    segmentStart = i + 1;
                 }
-                index++;
+            }
+            // Remaining input after the last signal (or all input if no signals)
+            if (segmentStart >= input.length) {
+                return; // all consumed by signals
+            }
+            if (segmentStart > 0) {
+                // Create trimmed array for the remainder
+                int[] remainder = new int[input.length - segmentStart];
+                System.arraycopy(input, segmentStart, remainder, 0, remainder.length);
+                input = remainder;
             }
         }
         // Filter theme DSR sequences if a handler is registered

--- a/terminal-api/src/main/java/org/aesh/terminal/parser/VtHandler.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/parser/VtHandler.java
@@ -1,0 +1,124 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aesh.terminal.parser;
+
+/**
+ * Callback interface for VT escape sequence parser events.
+ * <p>
+ * All methods have default no-op implementations so that consumers
+ * only need to override the events they care about.
+ * <p>
+ * The parameter arrays passed to callbacks are reused between calls —
+ * consumers must copy the data if they need to retain it.
+ *
+ * @see VtParser
+ */
+public interface VtHandler {
+
+    /**
+     * A printable character was received in the ground state.
+     *
+     * @param codePoint the character (0x20-0x7F or 0xA0-0xFF)
+     */
+    default void print(int codePoint) {
+    }
+
+    /**
+     * A C0 or C1 control character was received.
+     *
+     * @param controlChar the control character (0x00-0x1F, 0x80-0x9F)
+     */
+    default void execute(int controlChar) {
+    }
+
+    /**
+     * An escape sequence was completed.
+     * <p>
+     * Examples: {@code ESC M} (Reverse Index), {@code ESC ( B} (Select charset).
+     *
+     * @param finalChar the final character of the sequence
+     * @param intermediates the intermediate characters (0x20-0x2F)
+     * @param intermediateCount the number of intermediate characters
+     */
+    default void escDispatch(int finalChar, int[] intermediates, int intermediateCount) {
+    }
+
+    /**
+     * A CSI (Control Sequence Introducer) sequence was completed.
+     * <p>
+     * Examples: {@code CSI 2 J} (Erase Display), {@code CSI ? 1049 h} (Alt Screen).
+     * <p>
+     * The first intermediate may be a private marker (0x3C-0x3F: {@code < = > ?}).
+     * Parameter value {@code -1} indicates a default (empty) parameter.
+     *
+     * @param finalChar the final character (0x40-0x7E)
+     * @param params the parameter values (-1 = default)
+     * @param paramCount the number of parameters
+     * @param intermediates the intermediate/private-marker characters
+     * @param intermediateCount the number of intermediates
+     * @param hasSubParams true if colon-separated subparameters were present
+     */
+    default void csiDispatch(int finalChar, int[] params, int paramCount,
+            int[] intermediates, int intermediateCount,
+            boolean hasSubParams) {
+    }
+
+    /**
+     * A DCS (Device Control String) was started.
+     * <p>
+     * The first part of the DCS has been parsed (parameters, intermediates,
+     * final character). Subsequent data arrives via {@link #put(int)} until
+     * {@link #unhook()} is called.
+     *
+     * @param finalChar the final character determining the control function
+     * @param params the parameter values
+     * @param paramCount the number of parameters
+     * @param intermediates the intermediate characters
+     * @param intermediateCount the number of intermediates
+     */
+    default void hook(int finalChar, int[] params, int paramCount,
+            int[] intermediates, int intermediateCount) {
+    }
+
+    /**
+     * A data byte within a DCS passthrough string.
+     *
+     * @param b the data byte
+     */
+    default void put(int b) {
+    }
+
+    /**
+     * The DCS passthrough string has ended (ST, CAN, SUB, or ESC received).
+     */
+    default void unhook() {
+    }
+
+    /**
+     * An OSC (Operating System Command) string was completed.
+     * <p>
+     * Examples: {@code OSC 0 ; title BEL} (Set Title),
+     * {@code OSC 10 ; ? BEL} (Query Foreground Color).
+     *
+     * @param data the OSC string content (between the OSC introducer and terminator)
+     */
+    default void oscEnd(String data) {
+    }
+}

--- a/terminal-api/src/main/java/org/aesh/terminal/parser/VtParser.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/parser/VtParser.java
@@ -1,0 +1,587 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aesh.terminal.parser;
+
+/**
+ * Table-driven ANSI/VT escape sequence parser based on Paul Flo Williams'
+ * <a href="https://vt100.net/emu/dec_ansi_parser">DEC-compatible parser</a>.
+ * <p>
+ * The parser uses a pre-computed {@code short[14][256]} transition table where
+ * each entry encodes {@code (action << 4) | nextState}. This guarantees
+ * completeness (every byte in every state has a defined transition) and
+ * correctness (matches DEC VT220-VT525 observable behavior).
+ * <p>
+ * Deviations from Williams:
+ * <ul>
+ * <li>Colon (0x3A) is treated as a subparameter separator in CSI/DCS
+ * sequences, not as an error. This is required for SGR extended
+ * color sequences ({@code 38:2:R:G:B}).</li>
+ * <li>BEL (0x07) terminates OSC strings (xterm convention).</li>
+ * </ul>
+ * <p>
+ * Usage:
+ *
+ * <pre>
+ * VtParser parser = new VtParser(new VtHandler() {
+ *     public void csiDispatch(int finalChar, int[] params, int paramCount,
+ *             int[] intermediates, int intermediateCount,
+ *             boolean hasSubParams) {
+ *         // handle CSI sequence
+ *     }
+ *     // ... other callbacks
+ * });
+ * parser.advance(bytes, 0, length);
+ * </pre>
+ *
+ * @see VtHandler
+ * @see <a href="https://vt100.net/emu/dec_ansi_parser">Williams' VT parser</a>
+ */
+public final class VtParser {
+
+    // =========================================================================
+    // States (14 states, matching Williams exactly)
+    // =========================================================================
+
+    static final int GROUND = 0;
+    static final int ESCAPE = 1;
+    static final int ESCAPE_INTERMEDIATE = 2;
+    static final int CSI_ENTRY = 3;
+    static final int CSI_PARAM = 4;
+    static final int CSI_INTERMEDIATE = 5;
+    static final int CSI_IGNORE = 6;
+    static final int DCS_ENTRY = 7;
+    static final int DCS_PARAM = 8;
+    static final int DCS_INTERMEDIATE = 9;
+    static final int DCS_PASSTHROUGH = 10;
+    static final int DCS_IGNORE = 11;
+    static final int OSC_STRING = 12;
+    static final int SOS_PM_APC_STRING = 13;
+
+    static final int STATE_COUNT = 14;
+
+    // =========================================================================
+    // Actions (15 actions)
+    // =========================================================================
+
+    static final int ACTION_NONE = 0;
+    static final int ACTION_PRINT = 1;
+    static final int ACTION_EXECUTE = 2;
+    static final int ACTION_IGNORE = 3;
+    static final int ACTION_CLEAR = 4;
+    static final int ACTION_COLLECT = 5;
+    static final int ACTION_PARAM = 6;
+    static final int ACTION_ESC_DISPATCH = 7;
+    static final int ACTION_CSI_DISPATCH = 8;
+    static final int ACTION_HOOK = 9;
+    static final int ACTION_PUT = 10;
+    static final int ACTION_UNHOOK = 11;
+    static final int ACTION_OSC_START = 12;
+    static final int ACTION_OSC_PUT = 13;
+    static final int ACTION_OSC_END = 14;
+
+    // =========================================================================
+    // Table encoding: short = (action << 4) | nextState
+    // action=0 means no transition action (but entry/exit actions may fire)
+    // =========================================================================
+
+    private static short pack(int action, int state) {
+        return (short) ((action << 4) | state);
+    }
+
+    /**
+     * The transition table: TABLE[state][byte] = packed (action, nextState).
+     * Generated from the Williams specification with colon-as-subparam extension.
+     */
+    static final short[][] TABLE = new short[STATE_COUNT][256];
+
+    static {
+        buildTable();
+    }
+
+    // =========================================================================
+    // Parser state
+    // =========================================================================
+
+    private final VtHandler handler;
+    private int state = GROUND;
+
+    // Collected intermediates (max 2 per Williams, we allow 4 for safety)
+    private final int[] intermediates = new int[4];
+    private int intermediateCount;
+
+    // Collected parameters (max 16 per Williams, we allow 32 for modern usage)
+    private final int[] params = new int[32];
+    private int paramCount;
+    private boolean hasSubParams;
+
+    // Current parameter being accumulated
+    private int currentParam;
+    private boolean paramStarted;
+
+    // OSC string accumulator
+    private final StringBuilder oscString = new StringBuilder(256);
+
+    /**
+     * Creates a new parser with the given handler.
+     *
+     * @param handler the callback handler for parsed sequences
+     */
+    public VtParser(VtHandler handler) {
+        this.handler = handler;
+    }
+
+    /**
+     * Advances the parser with a block of input bytes.
+     *
+     * @param data the input bytes
+     * @param offset the start offset
+     * @param length the number of bytes to process
+     */
+    public void advance(byte[] data, int offset, int length) {
+        int end = offset + length;
+        for (int i = offset; i < end; i++) {
+            advance(data[i] & 0xFF);
+        }
+    }
+
+    /**
+     * Advances the parser with a block of code points.
+     * Code points &gt; 255 are treated as printable characters in the ground state
+     * and as ignored characters in other states.
+     *
+     * @param codePoints the input code points
+     * @param offset the start offset
+     * @param length the number of code points to process
+     */
+    public void advance(int[] codePoints, int offset, int length) {
+        int end = offset + length;
+        for (int i = offset; i < end; i++) {
+            advance(codePoints[i]);
+        }
+    }
+
+    /**
+     * Advances the parser with a single byte or code point.
+     * Values 0-255 use the transition table directly.
+     * Values &gt; 255 are treated as printable in ground state, ignored otherwise.
+     *
+     * @param b the byte (0-255) or code point (&gt; 255)
+     */
+    public void advance(int b) {
+        if (b > 255) {
+            // Code points beyond the table range: printable in ground, ignore elsewhere
+            if (state == GROUND) {
+                handler.print(b);
+            }
+            return;
+        }
+        short entry = TABLE[state][b];
+        int action = (entry >> 4) & 0x0F;
+        int nextState = entry & 0x0F;
+
+        // If state changes, perform exit action, transition action, entry action
+        if (nextState != state) {
+            performExitAction(state);
+            performAction(action, b);
+            performEntryAction(nextState);
+            state = nextState;
+        } else {
+            // Same state — just perform the action
+            performAction(action, b);
+        }
+    }
+
+    /**
+     * Resets the parser to ground state.
+     */
+    public void reset() {
+        if (state == DCS_PASSTHROUGH) {
+            handler.unhook();
+        } else if (state == OSC_STRING) {
+            handler.oscEnd(oscString.toString());
+        }
+        state = GROUND;
+        clearParams();
+    }
+
+    /**
+     * Returns the current state (for testing).
+     */
+    int getState() {
+        return state;
+    }
+
+    // =========================================================================
+    // Action dispatch
+    // =========================================================================
+
+    private void performAction(int action, int b) {
+        switch (action) {
+            case ACTION_NONE:
+                break;
+            case ACTION_PRINT:
+                handler.print(b);
+                break;
+            case ACTION_EXECUTE:
+                handler.execute(b);
+                break;
+            case ACTION_IGNORE:
+                break;
+            case ACTION_CLEAR:
+                clearParams();
+                break;
+            case ACTION_COLLECT:
+                if (intermediateCount < intermediates.length) {
+                    intermediates[intermediateCount++] = b;
+                }
+                break;
+            case ACTION_PARAM:
+                if (b == ';') {
+                    // Separator — store current param and start next
+                    flushParam();
+                } else if (b == ':') {
+                    // Subparameter separator
+                    flushParam();
+                    hasSubParams = true;
+                } else {
+                    // Digit 0-9
+                    currentParam = currentParam * 10 + (b - '0');
+                    paramStarted = true;
+                }
+                break;
+            case ACTION_ESC_DISPATCH:
+                handler.escDispatch(b, intermediates, intermediateCount);
+                break;
+            case ACTION_CSI_DISPATCH:
+                flushParam();
+                handler.csiDispatch(b, params, paramCount,
+                        intermediates, intermediateCount, hasSubParams);
+                break;
+            case ACTION_HOOK:
+                flushParam();
+                handler.hook(b, params, paramCount,
+                        intermediates, intermediateCount);
+                break;
+            case ACTION_PUT:
+                handler.put(b);
+                break;
+            case ACTION_UNHOOK:
+                handler.unhook();
+                break;
+            case ACTION_OSC_START:
+                oscString.setLength(0);
+                break;
+            case ACTION_OSC_PUT:
+                oscString.append((char) b);
+                break;
+            case ACTION_OSC_END:
+                handler.oscEnd(oscString.toString());
+                break;
+        }
+    }
+
+    private void performEntryAction(int newState) {
+        switch (newState) {
+            case ESCAPE:
+            case CSI_ENTRY:
+            case DCS_ENTRY:
+                clearParams();
+                break;
+            case OSC_STRING:
+                oscString.setLength(0);
+                break;
+            case DCS_PASSTHROUGH:
+                // hook is dispatched via the transition action
+                break;
+        }
+    }
+
+    private void performExitAction(int oldState) {
+        switch (oldState) {
+            case DCS_PASSTHROUGH:
+                handler.unhook();
+                break;
+            case OSC_STRING:
+                handler.oscEnd(oscString.toString());
+                break;
+        }
+    }
+
+    private void clearParams() {
+        intermediateCount = 0;
+        paramCount = 0;
+        currentParam = 0;
+        paramStarted = false;
+        hasSubParams = false;
+    }
+
+    private void flushParam() {
+        if (paramCount < params.length) {
+            params[paramCount++] = paramStarted ? currentParam : -1; // -1 = default
+        }
+        currentParam = 0;
+        paramStarted = false;
+    }
+
+    // =========================================================================
+    // Table generation — Williams spec + colon extension + BEL for OSC
+    // =========================================================================
+
+    private static void buildTable() {
+        // Initialize everything to (IGNORE, same state) — safe default
+        for (int s = 0; s < STATE_COUNT; s++) {
+            for (int b = 0; b < 256; b++) {
+                TABLE[s][b] = pack(ACTION_IGNORE, s);
+            }
+        }
+
+        // ---- "anywhere" transitions (from any state) ----
+        for (int s = 0; s < STATE_COUNT; s++) {
+            // CAN (0x18) and SUB (0x1A) → execute and go to ground
+            TABLE[s][0x18] = pack(ACTION_EXECUTE, GROUND);
+            TABLE[s][0x1A] = pack(ACTION_EXECUTE, GROUND);
+            // ESC (0x1B) → escape (no action — entry action does clear)
+            TABLE[s][0x1B] = pack(ACTION_NONE, ESCAPE);
+            // C1 controls (8-bit)
+            for (int b = 0x80; b <= 0x8F; b++)
+                TABLE[s][b] = pack(ACTION_EXECUTE, GROUND);
+            for (int b = 0x91; b <= 0x97; b++)
+                TABLE[s][b] = pack(ACTION_EXECUTE, GROUND);
+            TABLE[s][0x99] = pack(ACTION_EXECUTE, GROUND);
+            TABLE[s][0x9A] = pack(ACTION_EXECUTE, GROUND);
+            TABLE[s][0x90] = pack(ACTION_NONE, DCS_ENTRY); // DCS
+            TABLE[s][0x9B] = pack(ACTION_NONE, CSI_ENTRY); // CSI
+            TABLE[s][0x9C] = pack(ACTION_NONE, GROUND); // ST
+            TABLE[s][0x9D] = pack(ACTION_NONE, OSC_STRING); // OSC
+            TABLE[s][0x98] = pack(ACTION_NONE, SOS_PM_APC_STRING); // SOS
+            TABLE[s][0x9E] = pack(ACTION_NONE, SOS_PM_APC_STRING); // PM
+            TABLE[s][0x9F] = pack(ACTION_NONE, SOS_PM_APC_STRING); // APC
+        }
+
+        // ---- ground ----
+        for (int b = 0x00; b <= 0x17; b++)
+            TABLE[GROUND][b] = pack(ACTION_EXECUTE, GROUND);
+        TABLE[GROUND][0x19] = pack(ACTION_EXECUTE, GROUND);
+        for (int b = 0x1C; b <= 0x1F; b++)
+            TABLE[GROUND][b] = pack(ACTION_EXECUTE, GROUND);
+        for (int b = 0x20; b <= 0x7F; b++)
+            TABLE[GROUND][b] = pack(ACTION_PRINT, GROUND);
+
+        // ---- escape ----
+        for (int b = 0x00; b <= 0x17; b++)
+            TABLE[ESCAPE][b] = pack(ACTION_EXECUTE, ESCAPE);
+        TABLE[ESCAPE][0x19] = pack(ACTION_EXECUTE, ESCAPE);
+        for (int b = 0x1C; b <= 0x1F; b++)
+            TABLE[ESCAPE][b] = pack(ACTION_EXECUTE, ESCAPE);
+        for (int b = 0x20; b <= 0x2F; b++)
+            TABLE[ESCAPE][b] = pack(ACTION_COLLECT, ESCAPE_INTERMEDIATE);
+        for (int b = 0x30; b <= 0x4F; b++)
+            TABLE[ESCAPE][b] = pack(ACTION_ESC_DISPATCH, GROUND);
+        TABLE[ESCAPE][0x50] = pack(ACTION_NONE, DCS_ENTRY); // P → DCS
+        for (int b = 0x51; b <= 0x57; b++)
+            TABLE[ESCAPE][b] = pack(ACTION_ESC_DISPATCH, GROUND);
+        TABLE[ESCAPE][0x58] = pack(ACTION_NONE, SOS_PM_APC_STRING); // X → SOS
+        TABLE[ESCAPE][0x59] = pack(ACTION_ESC_DISPATCH, GROUND);
+        TABLE[ESCAPE][0x5A] = pack(ACTION_ESC_DISPATCH, GROUND);
+        TABLE[ESCAPE][0x5B] = pack(ACTION_NONE, CSI_ENTRY); // [ → CSI
+        TABLE[ESCAPE][0x5C] = pack(ACTION_ESC_DISPATCH, GROUND); // \ (ST as esc_dispatch)
+        TABLE[ESCAPE][0x5D] = pack(ACTION_NONE, OSC_STRING); // ] → OSC
+        TABLE[ESCAPE][0x5E] = pack(ACTION_NONE, SOS_PM_APC_STRING); // ^ → PM
+        TABLE[ESCAPE][0x5F] = pack(ACTION_NONE, SOS_PM_APC_STRING); // _ → APC
+        for (int b = 0x60; b <= 0x7E; b++)
+            TABLE[ESCAPE][b] = pack(ACTION_ESC_DISPATCH, GROUND);
+        TABLE[ESCAPE][0x7F] = pack(ACTION_IGNORE, ESCAPE);
+
+        // ---- escape intermediate ----
+        for (int b = 0x00; b <= 0x17; b++)
+            TABLE[ESCAPE_INTERMEDIATE][b] = pack(ACTION_EXECUTE, ESCAPE_INTERMEDIATE);
+        TABLE[ESCAPE_INTERMEDIATE][0x19] = pack(ACTION_EXECUTE, ESCAPE_INTERMEDIATE);
+        for (int b = 0x1C; b <= 0x1F; b++)
+            TABLE[ESCAPE_INTERMEDIATE][b] = pack(ACTION_EXECUTE, ESCAPE_INTERMEDIATE);
+        for (int b = 0x20; b <= 0x2F; b++)
+            TABLE[ESCAPE_INTERMEDIATE][b] = pack(ACTION_COLLECT, ESCAPE_INTERMEDIATE);
+        for (int b = 0x30; b <= 0x7E; b++)
+            TABLE[ESCAPE_INTERMEDIATE][b] = pack(ACTION_ESC_DISPATCH, GROUND);
+        TABLE[ESCAPE_INTERMEDIATE][0x7F] = pack(ACTION_IGNORE, ESCAPE_INTERMEDIATE);
+
+        // ---- csi entry ----
+        for (int b = 0x00; b <= 0x17; b++)
+            TABLE[CSI_ENTRY][b] = pack(ACTION_EXECUTE, CSI_ENTRY);
+        TABLE[CSI_ENTRY][0x19] = pack(ACTION_EXECUTE, CSI_ENTRY);
+        for (int b = 0x1C; b <= 0x1F; b++)
+            TABLE[CSI_ENTRY][b] = pack(ACTION_EXECUTE, CSI_ENTRY);
+        for (int b = 0x20; b <= 0x2F; b++)
+            TABLE[CSI_ENTRY][b] = pack(ACTION_COLLECT, CSI_INTERMEDIATE);
+        for (int b = 0x30; b <= 0x39; b++)
+            TABLE[CSI_ENTRY][b] = pack(ACTION_PARAM, CSI_PARAM);
+        TABLE[CSI_ENTRY][0x3A] = pack(ACTION_PARAM, CSI_PARAM); // colon → subparam (deviation from Williams)
+        TABLE[CSI_ENTRY][0x3B] = pack(ACTION_PARAM, CSI_PARAM); // semicolon
+        for (int b = 0x3C; b <= 0x3F; b++)
+            TABLE[CSI_ENTRY][b] = pack(ACTION_COLLECT, CSI_PARAM); // private markers
+        for (int b = 0x40; b <= 0x7E; b++)
+            TABLE[CSI_ENTRY][b] = pack(ACTION_CSI_DISPATCH, GROUND);
+        TABLE[CSI_ENTRY][0x7F] = pack(ACTION_IGNORE, CSI_ENTRY);
+
+        // ---- csi param ----
+        for (int b = 0x00; b <= 0x17; b++)
+            TABLE[CSI_PARAM][b] = pack(ACTION_EXECUTE, CSI_PARAM);
+        TABLE[CSI_PARAM][0x19] = pack(ACTION_EXECUTE, CSI_PARAM);
+        for (int b = 0x1C; b <= 0x1F; b++)
+            TABLE[CSI_PARAM][b] = pack(ACTION_EXECUTE, CSI_PARAM);
+        for (int b = 0x20; b <= 0x2F; b++)
+            TABLE[CSI_PARAM][b] = pack(ACTION_COLLECT, CSI_INTERMEDIATE);
+        for (int b = 0x30; b <= 0x39; b++)
+            TABLE[CSI_PARAM][b] = pack(ACTION_PARAM, CSI_PARAM);
+        TABLE[CSI_PARAM][0x3A] = pack(ACTION_PARAM, CSI_PARAM); // colon → subparam
+        TABLE[CSI_PARAM][0x3B] = pack(ACTION_PARAM, CSI_PARAM); // semicolon
+        for (int b = 0x3C; b <= 0x3F; b++)
+            TABLE[CSI_PARAM][b] = pack(ACTION_NONE, CSI_IGNORE);
+        for (int b = 0x40; b <= 0x7E; b++)
+            TABLE[CSI_PARAM][b] = pack(ACTION_CSI_DISPATCH, GROUND);
+        TABLE[CSI_PARAM][0x7F] = pack(ACTION_IGNORE, CSI_PARAM);
+
+        // ---- csi intermediate ----
+        for (int b = 0x00; b <= 0x17; b++)
+            TABLE[CSI_INTERMEDIATE][b] = pack(ACTION_EXECUTE, CSI_INTERMEDIATE);
+        TABLE[CSI_INTERMEDIATE][0x19] = pack(ACTION_EXECUTE, CSI_INTERMEDIATE);
+        for (int b = 0x1C; b <= 0x1F; b++)
+            TABLE[CSI_INTERMEDIATE][b] = pack(ACTION_EXECUTE, CSI_INTERMEDIATE);
+        for (int b = 0x20; b <= 0x2F; b++)
+            TABLE[CSI_INTERMEDIATE][b] = pack(ACTION_COLLECT, CSI_INTERMEDIATE);
+        for (int b = 0x30; b <= 0x3F; b++)
+            TABLE[CSI_INTERMEDIATE][b] = pack(ACTION_NONE, CSI_IGNORE);
+        for (int b = 0x40; b <= 0x7E; b++)
+            TABLE[CSI_INTERMEDIATE][b] = pack(ACTION_CSI_DISPATCH, GROUND);
+        TABLE[CSI_INTERMEDIATE][0x7F] = pack(ACTION_IGNORE, CSI_INTERMEDIATE);
+
+        // ---- csi ignore ----
+        for (int b = 0x00; b <= 0x17; b++)
+            TABLE[CSI_IGNORE][b] = pack(ACTION_EXECUTE, CSI_IGNORE);
+        TABLE[CSI_IGNORE][0x19] = pack(ACTION_EXECUTE, CSI_IGNORE);
+        for (int b = 0x1C; b <= 0x1F; b++)
+            TABLE[CSI_IGNORE][b] = pack(ACTION_EXECUTE, CSI_IGNORE);
+        for (int b = 0x20; b <= 0x3F; b++)
+            TABLE[CSI_IGNORE][b] = pack(ACTION_IGNORE, CSI_IGNORE);
+        for (int b = 0x40; b <= 0x7E; b++)
+            TABLE[CSI_IGNORE][b] = pack(ACTION_NONE, GROUND);
+        TABLE[CSI_IGNORE][0x7F] = pack(ACTION_IGNORE, CSI_IGNORE);
+
+        // ---- dcs entry ----
+        for (int b = 0x00; b <= 0x17; b++)
+            TABLE[DCS_ENTRY][b] = pack(ACTION_IGNORE, DCS_ENTRY);
+        TABLE[DCS_ENTRY][0x19] = pack(ACTION_IGNORE, DCS_ENTRY);
+        for (int b = 0x1C; b <= 0x1F; b++)
+            TABLE[DCS_ENTRY][b] = pack(ACTION_IGNORE, DCS_ENTRY);
+        for (int b = 0x20; b <= 0x2F; b++)
+            TABLE[DCS_ENTRY][b] = pack(ACTION_COLLECT, DCS_INTERMEDIATE);
+        for (int b = 0x30; b <= 0x39; b++)
+            TABLE[DCS_ENTRY][b] = pack(ACTION_PARAM, DCS_PARAM);
+        TABLE[DCS_ENTRY][0x3A] = pack(ACTION_NONE, DCS_IGNORE); // colon in DCS → ignore (no subparam in DCS)
+        TABLE[DCS_ENTRY][0x3B] = pack(ACTION_PARAM, DCS_PARAM);
+        for (int b = 0x3C; b <= 0x3F; b++)
+            TABLE[DCS_ENTRY][b] = pack(ACTION_COLLECT, DCS_PARAM);
+        for (int b = 0x40; b <= 0x7E; b++)
+            TABLE[DCS_ENTRY][b] = pack(ACTION_HOOK, DCS_PASSTHROUGH);
+        TABLE[DCS_ENTRY][0x7F] = pack(ACTION_IGNORE, DCS_ENTRY);
+
+        // ---- dcs param ----
+        for (int b = 0x00; b <= 0x17; b++)
+            TABLE[DCS_PARAM][b] = pack(ACTION_IGNORE, DCS_PARAM);
+        TABLE[DCS_PARAM][0x19] = pack(ACTION_IGNORE, DCS_PARAM);
+        for (int b = 0x1C; b <= 0x1F; b++)
+            TABLE[DCS_PARAM][b] = pack(ACTION_IGNORE, DCS_PARAM);
+        for (int b = 0x20; b <= 0x2F; b++)
+            TABLE[DCS_PARAM][b] = pack(ACTION_COLLECT, DCS_INTERMEDIATE);
+        for (int b = 0x30; b <= 0x39; b++)
+            TABLE[DCS_PARAM][b] = pack(ACTION_PARAM, DCS_PARAM);
+        TABLE[DCS_PARAM][0x3A] = pack(ACTION_NONE, DCS_IGNORE);
+        TABLE[DCS_PARAM][0x3B] = pack(ACTION_PARAM, DCS_PARAM);
+        for (int b = 0x3C; b <= 0x3F; b++)
+            TABLE[DCS_PARAM][b] = pack(ACTION_NONE, DCS_IGNORE);
+        for (int b = 0x40; b <= 0x7E; b++)
+            TABLE[DCS_PARAM][b] = pack(ACTION_HOOK, DCS_PASSTHROUGH);
+        TABLE[DCS_PARAM][0x7F] = pack(ACTION_IGNORE, DCS_PARAM);
+
+        // ---- dcs intermediate ----
+        for (int b = 0x00; b <= 0x17; b++)
+            TABLE[DCS_INTERMEDIATE][b] = pack(ACTION_IGNORE, DCS_INTERMEDIATE);
+        TABLE[DCS_INTERMEDIATE][0x19] = pack(ACTION_IGNORE, DCS_INTERMEDIATE);
+        for (int b = 0x1C; b <= 0x1F; b++)
+            TABLE[DCS_INTERMEDIATE][b] = pack(ACTION_IGNORE, DCS_INTERMEDIATE);
+        for (int b = 0x20; b <= 0x2F; b++)
+            TABLE[DCS_INTERMEDIATE][b] = pack(ACTION_COLLECT, DCS_INTERMEDIATE);
+        for (int b = 0x30; b <= 0x3F; b++)
+            TABLE[DCS_INTERMEDIATE][b] = pack(ACTION_NONE, DCS_IGNORE);
+        for (int b = 0x40; b <= 0x7E; b++)
+            TABLE[DCS_INTERMEDIATE][b] = pack(ACTION_HOOK, DCS_PASSTHROUGH);
+        TABLE[DCS_INTERMEDIATE][0x7F] = pack(ACTION_IGNORE, DCS_INTERMEDIATE);
+
+        // ---- dcs passthrough ----
+        for (int b = 0x00; b <= 0x17; b++)
+            TABLE[DCS_PASSTHROUGH][b] = pack(ACTION_PUT, DCS_PASSTHROUGH);
+        TABLE[DCS_PASSTHROUGH][0x19] = pack(ACTION_PUT, DCS_PASSTHROUGH);
+        for (int b = 0x1C; b <= 0x1F; b++)
+            TABLE[DCS_PASSTHROUGH][b] = pack(ACTION_PUT, DCS_PASSTHROUGH);
+        for (int b = 0x20; b <= 0x7E; b++)
+            TABLE[DCS_PASSTHROUGH][b] = pack(ACTION_PUT, DCS_PASSTHROUGH);
+        TABLE[DCS_PASSTHROUGH][0x7F] = pack(ACTION_IGNORE, DCS_PASSTHROUGH);
+        // 9C (ST) is handled by anywhere transitions
+
+        // ---- dcs ignore ----
+        for (int b = 0x00; b <= 0x17; b++)
+            TABLE[DCS_IGNORE][b] = pack(ACTION_IGNORE, DCS_IGNORE);
+        TABLE[DCS_IGNORE][0x19] = pack(ACTION_IGNORE, DCS_IGNORE);
+        for (int b = 0x1C; b <= 0x1F; b++)
+            TABLE[DCS_IGNORE][b] = pack(ACTION_IGNORE, DCS_IGNORE);
+        for (int b = 0x20; b <= 0x7F; b++)
+            TABLE[DCS_IGNORE][b] = pack(ACTION_IGNORE, DCS_IGNORE);
+        // 9C (ST) → ground is handled by anywhere transitions
+
+        // ---- osc string ----
+        for (int b = 0x00; b <= 0x06; b++)
+            TABLE[OSC_STRING][b] = pack(ACTION_IGNORE, OSC_STRING);
+        TABLE[OSC_STRING][0x07] = pack(ACTION_NONE, GROUND); // BEL terminates OSC (xterm extension)
+        for (int b = 0x08; b <= 0x17; b++)
+            TABLE[OSC_STRING][b] = pack(ACTION_IGNORE, OSC_STRING);
+        TABLE[OSC_STRING][0x19] = pack(ACTION_IGNORE, OSC_STRING);
+        for (int b = 0x1C; b <= 0x1F; b++)
+            TABLE[OSC_STRING][b] = pack(ACTION_IGNORE, OSC_STRING);
+        for (int b = 0x20; b <= 0x7F; b++)
+            TABLE[OSC_STRING][b] = pack(ACTION_OSC_PUT, OSC_STRING);
+        // 9C (ST) → ground is handled by anywhere transitions
+
+        // ---- sos/pm/apc string ----
+        for (int b = 0x00; b <= 0x17; b++)
+            TABLE[SOS_PM_APC_STRING][b] = pack(ACTION_IGNORE, SOS_PM_APC_STRING);
+        TABLE[SOS_PM_APC_STRING][0x19] = pack(ACTION_IGNORE, SOS_PM_APC_STRING);
+        for (int b = 0x1C; b <= 0x1F; b++)
+            TABLE[SOS_PM_APC_STRING][b] = pack(ACTION_IGNORE, SOS_PM_APC_STRING);
+        for (int b = 0x20; b <= 0x7F; b++)
+            TABLE[SOS_PM_APC_STRING][b] = pack(ACTION_IGNORE, SOS_PM_APC_STRING);
+        // 9C (ST) → ground is handled by anywhere transitions
+
+        // ---- GR area (0xA0-0xFF) → same as GL (0x20-0x7F) for all states ----
+        for (int s = 0; s < STATE_COUNT; s++) {
+            for (int b = 0xA0; b <= 0xFF; b++) {
+                TABLE[s][b] = TABLE[s][b - 0x80];
+            }
+        }
+    }
+}

--- a/terminal-api/src/test/java/org/aesh/terminal/parser/VtParserTest.java
+++ b/terminal-api/src/test/java/org/aesh/terminal/parser/VtParserTest.java
@@ -1,0 +1,544 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aesh.terminal.parser;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Tests for the VT escape sequence parser.
+ */
+public class VtParserTest {
+
+    // ==================== Helper ====================
+
+    /** Records all parser events for assertion. */
+    static class RecordingHandler implements VtHandler {
+        final List<String> events = new ArrayList<>();
+
+        @Override
+        public void print(int codePoint) {
+            events.add("print:" + (char) codePoint);
+        }
+
+        @Override
+        public void execute(int controlChar) {
+            events.add("execute:0x" + Integer.toHexString(controlChar));
+        }
+
+        @Override
+        public void escDispatch(int finalChar, int[] intermediates, int intermediateCount) {
+            StringBuilder sb = new StringBuilder("esc:");
+            for (int i = 0; i < intermediateCount; i++) {
+                sb.append((char) intermediates[i]);
+            }
+            sb.append((char) finalChar);
+            events.add(sb.toString());
+        }
+
+        @Override
+        public void csiDispatch(int finalChar, int[] params, int paramCount,
+                int[] intermediates, int intermediateCount,
+                boolean hasSubParams) {
+            StringBuilder sb = new StringBuilder("csi:");
+            for (int i = 0; i < intermediateCount; i++) {
+                sb.append((char) intermediates[i]);
+            }
+            sb.append('[');
+            for (int i = 0; i < paramCount; i++) {
+                if (i > 0)
+                    sb.append(',');
+                sb.append(params[i]);
+            }
+            sb.append(']');
+            sb.append((char) finalChar);
+            if (hasSubParams)
+                sb.append(":sub");
+            events.add(sb.toString());
+        }
+
+        @Override
+        public void hook(int finalChar, int[] params, int paramCount,
+                int[] intermediates, int intermediateCount) {
+            events.add("hook:" + (char) finalChar);
+        }
+
+        @Override
+        public void put(int b) {
+            events.add("put:" + (char) b);
+        }
+
+        @Override
+        public void unhook() {
+            events.add("unhook");
+        }
+
+        @Override
+        public void oscEnd(String data) {
+            events.add("osc:" + data);
+        }
+    }
+
+    private void feed(VtParser parser, String s) {
+        byte[] bytes = s.getBytes();
+        parser.advance(bytes, 0, bytes.length);
+    }
+
+    // ==================== Ground state ====================
+
+    @Test
+    public void testPrintableText() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        feed(p, "Hello");
+        assertEquals(Arrays.asList(
+                "print:H", "print:e", "print:l", "print:l", "print:o"),
+                h.events);
+    }
+
+    @Test
+    public void testC0Controls() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        feed(p, "\r\n\t");
+        assertEquals(Arrays.asList(
+                "execute:0xd", "execute:0xa", "execute:0x9"),
+                h.events);
+    }
+
+    @Test
+    public void testMixedTextAndControls() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        feed(p, "A\nB");
+        assertEquals(Arrays.asList(
+                "print:A", "execute:0xa", "print:B"),
+                h.events);
+    }
+
+    // ==================== ESC sequences ====================
+
+    @Test
+    public void testSimpleEscSequence() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // ESC M = Reverse Index
+        feed(p, "\033M");
+        assertEquals(Arrays.asList("esc:M"), h.events);
+        assertEquals(VtParser.GROUND, p.getState());
+    }
+
+    @Test
+    public void testEscWithIntermediate() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // ESC ( B = Select ASCII charset
+        feed(p, "\033(B");
+        assertEquals(Arrays.asList("esc:(B"), h.events);
+    }
+
+    @Test
+    public void testEscSaveCursor() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // ESC 7 = Save Cursor (DECSC)
+        feed(p, "\0337");
+        assertEquals(Arrays.asList("esc:7"), h.events);
+    }
+
+    // ==================== CSI sequences ====================
+
+    @Test
+    public void testCsiNoParams() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // CSI H = Cursor Home (no params = defaults)
+        feed(p, "\033[H");
+        assertEquals(1, h.events.size());
+        assertEquals("csi:[-1]H", h.events.get(0));
+    }
+
+    @Test
+    public void testCsiSingleParam() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // CSI 2 J = Erase Display
+        feed(p, "\033[2J");
+        assertEquals("csi:[2]J", h.events.get(0));
+    }
+
+    @Test
+    public void testCsiMultipleParams() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // CSI 10;20 H = Cursor Position (row 10, col 20)
+        feed(p, "\033[10;20H");
+        assertEquals("csi:[10,20]H", h.events.get(0));
+    }
+
+    @Test
+    public void testCsiDefaultParams() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // CSI ;5 H = Cursor Position (default row, col 5)
+        feed(p, "\033[;5H");
+        assertEquals("csi:[-1,5]H", h.events.get(0));
+    }
+
+    @Test
+    public void testCsiPrivateMarker() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // CSI ? 1049 h = Enable alt screen
+        feed(p, "\033[?1049h");
+        assertEquals("csi:?[1049]h", h.events.get(0));
+    }
+
+    @Test
+    public void testCsiSgrColors() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // CSI 38;2;255;0;128 m = Set foreground to RGB
+        feed(p, "\033[38;2;255;0;128m");
+        assertEquals("csi:[38,2,255,0,128]m", h.events.get(0));
+    }
+
+    @Test
+    public void testCsiColonSubParams() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // CSI 38:2:255:0:128 m = Set foreground to RGB (colon syntax)
+        feed(p, "\033[38:2:255:0:128m");
+        assertTrue(h.events.get(0).endsWith(":sub"));
+    }
+
+    @Test
+    public void testCsiArrowKeys() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // Up, Down, Right, Left
+        feed(p, "\033[A\033[B\033[C\033[D");
+        assertEquals(4, h.events.size());
+        assertEquals("csi:[-1]A", h.events.get(0));
+        assertEquals("csi:[-1]B", h.events.get(1));
+        assertEquals("csi:[-1]C", h.events.get(2));
+        assertEquals("csi:[-1]D", h.events.get(3));
+    }
+
+    @Test
+    public void testCsiC0Executed() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // CSI with embedded LF — C0 should be executed inline per Williams
+        feed(p, "\033[2\nJ");
+        assertEquals(2, h.events.size());
+        assertEquals("execute:0xa", h.events.get(0));
+        assertEquals("csi:[2]J", h.events.get(1));
+    }
+
+    // ==================== CSI error recovery ====================
+
+    @Test
+    public void testCsiIgnoreOnInvalidPrivateMarker() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // CSI ? after params → csi_ignore
+        feed(p, "\033[1?H");
+        // Should NOT dispatch — the sequence is ignored
+        assertTrue(h.events.isEmpty());
+        assertEquals(VtParser.GROUND, p.getState());
+    }
+
+    @Test
+    public void testCsiIgnoreParamAfterIntermediate() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // CSI with param after intermediate → csi_ignore
+        feed(p, "\033[ 1H");
+        // Space is intermediate (0x20), then '1' is param → error → ignore
+        assertTrue(h.events.isEmpty());
+    }
+
+    // ==================== OSC sequences ====================
+
+    @Test
+    public void testOscBelTerminated() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // OSC 0 ; title BEL = Set window title
+        feed(p, "\033]0;My Title\007");
+        assertEquals(1, h.events.size());
+        assertEquals("osc:0;My Title", h.events.get(0));
+        assertEquals(VtParser.GROUND, p.getState());
+    }
+
+    @Test
+    public void testOscStTerminated() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // OSC 0 ; title ST (ESC \) = Set window title
+        feed(p, "\033]0;My Title\033\\");
+        // OSC ends on ESC (which cancels to escape state), then \ dispatches
+        assertEquals(2, h.events.size());
+        assertEquals("osc:0;My Title", h.events.get(0));
+        // The \ after ESC is an esc_dispatch
+        assertEquals("esc:\\", h.events.get(1));
+    }
+
+    @Test
+    public void testOscColorQuery() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // OSC 10 ; rgb:ffff/8080/0000 BEL = foreground color response
+        feed(p, "\033]10;rgb:ffff/8080/0000\007");
+        assertEquals("osc:10;rgb:ffff/8080/0000", h.events.get(0));
+    }
+
+    // ==================== DCS sequences ====================
+
+    @Test
+    public void testDcsPassthrough() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // DCS q ... ST = Sixel data
+        feed(p, "\033Pq#0;2;0;0;0\033\\");
+        assertTrue(h.events.get(0).equals("hook:q"));
+        // Data bytes: #0;2;0;0;0
+        assertTrue(h.events.contains("put:#"));
+        assertTrue(h.events.contains("unhook"));
+    }
+
+    // ==================== Anywhere transitions ====================
+
+    @Test
+    public void testEscCancelsSequence() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // Start a CSI, then cancel with ESC M
+        feed(p, "\033[1\033M");
+        // The CSI is cancelled, ESC M is dispatched
+        assertEquals(1, h.events.size());
+        assertEquals("esc:M", h.events.get(0));
+    }
+
+    @Test
+    public void testCanCancelsToGround() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // Start a CSI, cancel with CAN (0x18)
+        feed(p, "\033[1\030X");
+        // CAN executes and goes to ground, then X is printed
+        assertEquals(Arrays.asList("execute:0x18", "print:X"), h.events);
+    }
+
+    @Test
+    public void testSubCancelsToGround() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // Start a CSI, cancel with SUB (0x1A)
+        feed(p, "\033[1\032X");
+        assertEquals(Arrays.asList("execute:0x1a", "print:X"), h.events);
+    }
+
+    // ==================== DA1/DA2 responses ====================
+
+    @Test
+    public void testDa1Response() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // DA1 response: CSI ? 65 ; 1 ; 9 c
+        feed(p, "\033[?65;1;9c");
+        assertEquals("csi:?[65,1,9]c", h.events.get(0));
+    }
+
+    @Test
+    public void testDa2Response() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // DA2 response: CSI > 1 ; 4600 ; 0 c
+        feed(p, "\033[>1;4600;0c");
+        assertEquals("csi:>[1,4600,0]c", h.events.get(0));
+    }
+
+    // ==================== Mouse events (SGR) ====================
+
+    @Test
+    public void testSgrMousePress() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // CSI < 0 ; 5 ; 3 M = Left button press at (5,3)
+        feed(p, "\033[<0;5;3M");
+        assertEquals("csi:<[0,5,3]M", h.events.get(0));
+    }
+
+    @Test
+    public void testSgrMouseRelease() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // CSI < 0 ; 5 ; 3 m = Left button release at (5,3)
+        feed(p, "\033[<0;5;3m");
+        assertEquals("csi:<[0,5,3]m", h.events.get(0));
+    }
+
+    // ==================== SOS/PM/APC strings ====================
+
+    @Test
+    public void testSosIgnored() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // ESC X (SOS) ... ESC \ (ST)
+        feed(p, "\033Xsome data\033\\");
+        // SOS content is ignored, ESC cancels, \ is esc_dispatch
+        assertEquals(1, h.events.size());
+        assertEquals("esc:\\", h.events.get(0));
+    }
+
+    @Test
+    public void testApcIgnored() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // ESC _ (APC) ... ESC \ (ST)
+        feed(p, "\033_app data\033\\");
+        assertEquals(1, h.events.size());
+        assertEquals("esc:\\", h.events.get(0));
+    }
+
+    // ==================== Table completeness ====================
+
+    @Test
+    public void testTableCompleteness() {
+        // Verify every state/byte combination has a defined entry
+        for (int s = 0; s < VtParser.STATE_COUNT; s++) {
+            for (int b = 0; b < 256; b++) {
+                short entry = VtParser.TABLE[s][b];
+                int action = (entry >> 4) & 0x0F;
+                int nextState = entry & 0x0F;
+                assertTrue("State " + s + " byte " + b + ": nextState out of range",
+                        nextState >= 0 && nextState < VtParser.STATE_COUNT);
+                assertTrue("State " + s + " byte " + b + ": action out of range",
+                        action >= 0 && action <= 14);
+            }
+        }
+    }
+
+    @Test
+    public void testGrEqualsGl() {
+        // Williams: GR area (A0-FF) treated identically to GL (20-7F) in all states
+        for (int s = 0; s < VtParser.STATE_COUNT; s++) {
+            for (int b = 0xA0; b <= 0xFF; b++) {
+                assertEquals(
+                        "State " + s + ": GR byte " + b + " should match GL byte " + (b - 0x80),
+                        VtParser.TABLE[s][b - 0x80],
+                        VtParser.TABLE[s][b]);
+            }
+        }
+    }
+
+    // ==================== Byte-at-a-time vs batch ====================
+
+    @Test
+    public void testByteAtATimeMatchesBatch() {
+        String input = "\033[?1049h\033]0;title\007\033[38;2;255;0;0mHello\033[0m";
+
+        RecordingHandler h1 = new RecordingHandler();
+        VtParser p1 = new VtParser(h1);
+        byte[] bytes = input.getBytes();
+        p1.advance(bytes, 0, bytes.length);
+
+        RecordingHandler h2 = new RecordingHandler();
+        VtParser p2 = new VtParser(h2);
+        for (byte b : bytes) {
+            p2.advance(b & 0xFF);
+        }
+
+        assertEquals(h1.events, h2.events);
+    }
+
+    // ==================== Code point input ====================
+
+    @Test
+    public void testCodePointArray() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        int[] cps = { 'H', 'i' };
+        p.advance(cps, 0, cps.length);
+        assertEquals(Arrays.asList("print:H", "print:i"), h.events);
+    }
+
+    @Test
+    public void testHighCodePointsArePrintable() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // Unicode code point > 255 should be treated as printable in ground state
+        p.advance(0x1F600); // emoji
+        assertEquals(1, h.events.size());
+        // print event with the code point value
+        assertTrue(h.events.get(0).startsWith("print:"));
+    }
+
+    @Test
+    public void testHighCodePointsIgnoredInEscapeState() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // Start ESC, then feed a high code point — should be ignored, not printed
+        p.advance(0x1B); // ESC
+        p.advance(0x1F600); // high code point in escape state — ignored
+        p.advance('M'); // complete ESC M
+        // Only the ESC M should produce an event
+        assertEquals(Arrays.asList("esc:M"), h.events);
+    }
+
+    @Test
+    public void testCsiViaCodePoints() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        int[] cps = { 0x1B, '[', '2', 'J' };
+        p.advance(cps, 0, cps.length);
+        assertEquals("csi:[2]J", h.events.get(0));
+    }
+
+    // ==================== Partial input ====================
+
+    @Test
+    public void testPartialCsiAcrossAdvanceCalls() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        // Split CSI 2 J across two advance() calls
+        feed(p, "\033[");
+        assertTrue(h.events.isEmpty()); // not dispatched yet
+        feed(p, "2J");
+        assertEquals("csi:[2]J", h.events.get(0));
+    }
+
+    @Test
+    public void testPartialOscAcrossAdvanceCalls() {
+        RecordingHandler h = new RecordingHandler();
+        VtParser p = new VtParser(h);
+        feed(p, "\033]0;My");
+        assertTrue(h.events.isEmpty());
+        feed(p, " Title\007");
+        assertEquals("osc:0;My Title", h.events.get(0));
+    }
+}


### PR DESCRIPTION
Add VtParser, a general-purpose escape sequence parser based on Paul Flo Williams' DEC-compatible VT parser state machine. Uses a pre-computed short[14][256] transition table (~7KB) where each entry encodes (action << 4 | nextState), guaranteeing completeness and correctness for all sequence types.

Parser (terminal-api):
- 14 states from Williams spec: ground, escape, escape_intermediate, csi_entry/param/intermediate/ignore, dcs_entry/param/intermediate/ passthrough/ignore, osc_string, sos_pm_apc_string
- VtHandler callback interface with default no-ops
- Supports both byte[] and int[] code point input
- Colon (0x3A) as subparameter separator (SGR extended colors)
- BEL (0x07) terminates OSC strings (xterm convention)

ActionDecoder integration (readline):
- Uses VtParser as fallback when KeyMappingTrie has no match for escape sequences. Unknown CSI/OSC/DCS sequences are consumed as complete SequenceKeyAction units instead of leaking byte-by-byte.
- Pre-allocated buffer with offset tracking replaces copy-on-grow and copy-on-consume arrays, eliminating per-keystroke allocations.
- Reusable VtParser + SequenceMeasurer instance (not per-call).

KeyMappingTrie optimization:
- Track childCount on TrieNode instead of scanning 256-slot array.
- Add match(int[], offset, length) overload for offset-based buffer.
- MatchResult allocation is effectively free via HotSpot escape analysis (measured at 0.87 ns vs 4.81 ns for packed-long alternative — escape analysis wins).

EventDecoder optimization:
- Single-pass signal extraction replaces re-scanning loop that copied remainder arrays on each signal found.

JMH benchmarks:
- VtParserBenchmark: printable text, CSI, OSC, mouse, mixed input
- KeyMappingTrieBenchmark: single-byte, multi-byte, unknown sequences
- EventDecoderBenchmark: signals, DSR filter, throughput
- Fixes missing Prompt import in BufferBenchmark, TuiOutputBenchmark

Benchmark results (Java 25, x86_64):
  ActionDecoder single char:  26 ns (was 29 ns, -10%)
  ActionDecoder arrow key:    74 ns (was 113 ns, -35%)
  ActionDecoder typing sim:  187 ns (was 279 ns, -33%)
  KeyMappingTrie single:    0.87 ns
  KeyMappingTrie arrow:     3.37 ns
  VtParser arrow key:         22 ns
  VtParser mixed (93 bytes): 231 ns (2.5 ns/byte)

Fixes #160