### PR TITLE
Add mouse tracking protocol support

### DIFF
--- a/terminal-api/src/main/java/org/aesh/terminal/AbstractConnection.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/AbstractConnection.java
@@ -120,6 +120,16 @@ public abstract class AbstractConnection implements Connection {
     }
 
     @Override
+    public void setMouseHandler(java.util.function.Consumer<org.aesh.terminal.tty.MouseEvent> handler) {
+        eventDecoder.setMouseHandler(handler);
+    }
+
+    @Override
+    public java.util.function.Consumer<org.aesh.terminal.tty.MouseEvent> mouseHandler() {
+        return eventDecoder.getMouseHandler();
+    }
+
+    @Override
     public boolean reading() {
         return reading;
     }

--- a/terminal-api/src/main/java/org/aesh/terminal/Connection.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/Connection.java
@@ -176,6 +176,29 @@ public interface Connection extends Appendable, AutoCloseable {
         return null;
     }
 
+    /**
+     * Set a handler to be called when mouse events are received.
+     * <p>
+     * Mouse tracking must be explicitly enabled via {@link org.aesh.terminal.tty.MouseTracking}
+     * for the terminal to send mouse events.
+     *
+     * @param handler the handler to invoke with mouse events, or null to remove
+     * @see org.aesh.terminal.tty.MouseTracking
+     * @see org.aesh.terminal.tty.MouseEvent
+     */
+    default void setMouseHandler(Consumer<org.aesh.terminal.tty.MouseEvent> handler) {
+        // Default no-op; AbstractConnection delegates to EventDecoder
+    }
+
+    /**
+     * Get the current mouse event handler.
+     *
+     * @return the mouse handler, or null if not set
+     */
+    default Consumer<org.aesh.terminal.tty.MouseEvent> mouseHandler() {
+        return null;
+    }
+
     // ==================== Lifecycle ====================
 
     /**

--- a/terminal-api/src/main/java/org/aesh/terminal/EventDecoder.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/EventDecoder.java
@@ -25,6 +25,7 @@ import java.util.Queue;
 import java.util.function.Consumer;
 
 import org.aesh.terminal.detect.TerminalTheme;
+import org.aesh.terminal.tty.MouseEvent;
 import org.aesh.terminal.tty.Signal;
 import org.aesh.terminal.utils.ANSI;
 
@@ -49,8 +50,25 @@ public class EventDecoder implements Consumer<int[]> {
     private Consumer<Signal> signalHandler;
     private Consumer<int[]> inputHandler;
     private Consumer<TerminalTheme> themeChangeHandler;
+    private Consumer<MouseEvent> mouseHandler;
 
     private final Queue<int[]> inputQueue = new ArrayDeque<>(10);
+
+    // ---- Mouse SGR sequence detection ----
+    // SGR mouse format: ESC [ < Pb ; Px ; Py M/m
+    // We detect this as: ESC(27) [(91) <(60) digits ;(59) digits ;(59) digits M(77)/m(109)
+    private static final int MOUSE_IDLE = 0;
+    private static final int MOUSE_AFTER_ESC = 1; // seen ESC
+    private static final int MOUSE_AFTER_CSI = 2; // seen ESC [
+    private static final int MOUSE_AFTER_LT = 3; // seen ESC [ <
+    private static final int MOUSE_PARAM1 = 4; // collecting Pb digits
+    private static final int MOUSE_PARAM2 = 5; // collecting Px digits
+    private static final int MOUSE_PARAM3 = 6; // collecting Py digits
+
+    private int mouseState = MOUSE_IDLE;
+    private int mouseParam1, mouseParam2, mouseParam3;
+    private int[] mousePending = new int[16];
+    private int mousePendingLen;
 
     // ---- Theme DSR state machine ----
     // The prefix we're matching: ESC [ ? 9 9 7 ;
@@ -156,6 +174,32 @@ public class EventDecoder implements Consumer<int[]> {
     }
 
     /**
+     * Get the current mouse event handler.
+     *
+     * @return the mouse handler, or null if not set
+     */
+    public Consumer<MouseEvent> getMouseHandler() {
+        return mouseHandler;
+    }
+
+    /**
+     * Set the handler for mouse events.
+     * <p>
+     * When set, the decoder will intercept SGR mouse sequences
+     * ({@code CSI < Pb ; Px ; Py M/m}) from the input stream and
+     * invoke this handler instead of passing them through as input.
+     *
+     * @param mouseHandler the handler, or null to disable interception
+     */
+    public void setMouseHandler(Consumer<MouseEvent> mouseHandler) {
+        this.mouseHandler = mouseHandler;
+        if (mouseHandler == null) {
+            mouseState = MOUSE_IDLE;
+            mousePendingLen = 0;
+        }
+    }
+
+    /**
      * Set the handler for theme change DSR notifications.
      * <p>
      * When set, the decoder will intercept {@code CSI ? 997 ; Ps n} sequences
@@ -230,6 +274,10 @@ public class EventDecoder implements Consumer<int[]> {
         // Filter theme DSR sequences if a handler is registered
         if (input.length > 0 && themeChangeHandler != null) {
             input = filterThemeDsr(input);
+        }
+        // Filter mouse SGR sequences if a handler is registered
+        if (input.length > 0 && mouseHandler != null) {
+            input = filterMouseSgr(input);
         }
         if (input.length > 0) {
             if (inputHandler != null)
@@ -367,6 +415,154 @@ public class EventDecoder implements Consumer<int[]> {
         dsrPendingLen = 0;
         dsrState = DSR_IDLE;
         dsrParamValue = 0;
+        return outLen;
+    }
+
+    // =========================================================================
+    // Mouse SGR sequence filtering
+    // =========================================================================
+
+    /**
+     * Filter SGR mouse sequences ({@code ESC [ < Pb ; Px ; Py M/m}) from input.
+     * Recognized sequences are parsed into {@link MouseEvent} and dispatched
+     * to the mouse handler. Non-matching bytes are passed through unchanged.
+     */
+    private int[] filterMouseSgr(int[] input) {
+        // Fast path: if not mid-sequence and no ESC in input, pass through
+        if (mouseState == MOUSE_IDLE) {
+            boolean hasEsc = false;
+            for (int c : input) {
+                if (c == 27) {
+                    hasEsc = true;
+                    break;
+                }
+            }
+            if (!hasEsc)
+                return input;
+        }
+
+        int[] output = new int[input.length + mousePendingLen];
+        int outLen = 0;
+
+        for (int i = 0; i < input.length; i++) {
+            int cp = input[i];
+
+            switch (mouseState) {
+                case MOUSE_IDLE:
+                    if (cp == 27) {
+                        mouseState = MOUSE_AFTER_ESC;
+                        mousePendingLen = 0;
+                        appendMousePending(cp);
+                    } else {
+                        output[outLen++] = cp;
+                    }
+                    break;
+
+                case MOUSE_AFTER_ESC:
+                    if (cp == 91) { // [
+                        mouseState = MOUSE_AFTER_CSI;
+                        appendMousePending(cp);
+                    } else {
+                        // Not CSI — flush pending and re-process
+                        outLen = flushMousePending(output, outLen);
+                        i--;
+                    }
+                    break;
+
+                case MOUSE_AFTER_CSI:
+                    if (cp == 60) { // <
+                        mouseState = MOUSE_AFTER_LT;
+                        mouseParam1 = 0;
+                        mouseParam2 = 0;
+                        mouseParam3 = 0;
+                        appendMousePending(cp);
+                    } else {
+                        // Not < — not a mouse sequence, flush and re-process
+                        outLen = flushMousePending(output, outLen);
+                        i--;
+                    }
+                    break;
+
+                case MOUSE_AFTER_LT:
+                    // Expect first digit of Pb
+                    if (cp >= '0' && cp <= '9') {
+                        mouseState = MOUSE_PARAM1;
+                        mouseParam1 = cp - '0';
+                        appendMousePending(cp);
+                    } else {
+                        outLen = flushMousePending(output, outLen);
+                        i--;
+                    }
+                    break;
+
+                case MOUSE_PARAM1:
+                    if (cp >= '0' && cp <= '9') {
+                        mouseParam1 = mouseParam1 * 10 + (cp - '0');
+                        appendMousePending(cp);
+                    } else if (cp == ';') {
+                        mouseState = MOUSE_PARAM2;
+                        appendMousePending(cp);
+                    } else {
+                        outLen = flushMousePending(output, outLen);
+                        i--;
+                    }
+                    break;
+
+                case MOUSE_PARAM2:
+                    if (cp >= '0' && cp <= '9') {
+                        mouseParam2 = mouseParam2 * 10 + (cp - '0');
+                        appendMousePending(cp);
+                    } else if (cp == ';') {
+                        mouseState = MOUSE_PARAM3;
+                        appendMousePending(cp);
+                    } else {
+                        outLen = flushMousePending(output, outLen);
+                        i--;
+                    }
+                    break;
+
+                case MOUSE_PARAM3:
+                    if (cp >= '0' && cp <= '9') {
+                        mouseParam3 = mouseParam3 * 10 + (cp - '0');
+                        appendMousePending(cp);
+                    } else if (cp == 'M' || cp == 'm') {
+                        // Complete mouse sequence!
+                        MouseEvent event = MouseEvent.parseSgr(cp,
+                                new int[] { mouseParam1, mouseParam2, mouseParam3 }, 3);
+                        mouseState = MOUSE_IDLE;
+                        mousePendingLen = 0;
+                        if (event != null && mouseHandler != null) {
+                            mouseHandler.accept(event);
+                        }
+                    } else {
+                        outLen = flushMousePending(output, outLen);
+                        i--;
+                    }
+                    break;
+            }
+        }
+
+        if (outLen == 0 && mouseState == MOUSE_IDLE) {
+            return new int[0];
+        }
+        if (outLen == input.length && mousePendingLen == 0) {
+            return input;
+        }
+        return Arrays.copyOf(output, outLen);
+    }
+
+    private void appendMousePending(int cp) {
+        if (mousePendingLen >= mousePending.length) {
+            mousePending = Arrays.copyOf(mousePending, mousePending.length * 2);
+        }
+        mousePending[mousePendingLen++] = cp;
+    }
+
+    private int flushMousePending(int[] output, int outLen) {
+        System.arraycopy(mousePending, 0, output, outLen, mousePendingLen);
+        outLen += mousePendingLen;
+        mousePendingLen = 0;
+        mouseState = MOUSE_IDLE;
         return outLen;
     }
 }

--- a/terminal-api/src/main/java/org/aesh/terminal/tty/MouseEvent.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/tty/MouseEvent.java
@@ -1,0 +1,290 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aesh.terminal.tty;
+
+/**
+ * Represents a mouse event from the terminal.
+ * <p>
+ * Mouse events are produced when mouse tracking is enabled via
+ * {@link MouseTracking} and the terminal sends mouse reports.
+ * The event includes the type (press, release, drag, move, scroll),
+ * the button involved, the position (1-based), and modifier keys.
+ *
+ * @see MouseTracking
+ */
+public final class MouseEvent {
+
+    /**
+     * The type of mouse event.
+     */
+    public enum Type {
+        /** A button was pressed. */
+        PRESS,
+        /** A button was released. */
+        RELEASE,
+        /** The mouse was moved while a button was held (drag). */
+        DRAG,
+        /** The mouse was moved with no button held (hover). */
+        MOVE,
+        /** The scroll wheel was used. */
+        SCROLL
+    }
+
+    /**
+     * The mouse button involved in the event.
+     */
+    public enum Button {
+        /** Left mouse button. */
+        LEFT,
+        /** Middle mouse button. */
+        MIDDLE,
+        /** Right mouse button. */
+        RIGHT,
+        /** Scroll wheel up. */
+        SCROLL_UP,
+        /** Scroll wheel down. */
+        SCROLL_DOWN,
+        /** No button (used for move events and legacy release). */
+        NONE
+    }
+
+    private final Type type;
+    private final Button button;
+    private final int x;
+    private final int y;
+    private final boolean shift;
+    private final boolean alt;
+    private final boolean ctrl;
+
+    /**
+     * Creates a new mouse event.
+     *
+     * @param type the event type
+     * @param button the button
+     * @param x the column (1-based)
+     * @param y the row (1-based)
+     * @param shift true if shift was held
+     * @param alt true if alt/meta was held
+     * @param ctrl true if ctrl was held
+     */
+    public MouseEvent(Type type, Button button, int x, int y,
+            boolean shift, boolean alt, boolean ctrl) {
+        this.type = type;
+        this.button = button;
+        this.x = x;
+        this.y = y;
+        this.shift = shift;
+        this.alt = alt;
+        this.ctrl = ctrl;
+    }
+
+    /** Returns the event type. */
+    public Type type() {
+        return type;
+    }
+
+    /** Returns the button. */
+    public Button button() {
+        return button;
+    }
+
+    /** Returns the column (1-based). */
+    public int x() {
+        return x;
+    }
+
+    /** Returns the row (1-based). */
+    public int y() {
+        return y;
+    }
+
+    /** Returns true if shift was held. */
+    public boolean shift() {
+        return shift;
+    }
+
+    /** Returns true if alt/meta was held. */
+    public boolean alt() {
+        return alt;
+    }
+
+    /** Returns true if ctrl was held. */
+    public boolean ctrl() {
+        return ctrl;
+    }
+
+    // =========================================================================
+    // SGR mouse parsing
+    // =========================================================================
+
+    /**
+     * Parses an SGR mouse event from a CSI dispatch.
+     * <p>
+     * SGR format: {@code CSI < Pb ; Px ; Py M} (press/drag/move/scroll)
+     * or {@code CSI < Pb ; Px ; Py m} (release).
+     * <p>
+     * This method is designed to be called directly from a
+     * {@link org.aesh.terminal.parser.VtHandler#csiDispatch} callback
+     * when the private marker is {@code <}.
+     *
+     * @param finalChar the final character ('M' for press, 'm' for release)
+     * @param params the CSI parameters [Pb, Px, Py]
+     * @param paramCount the number of parameters (must be 3)
+     * @return the parsed mouse event, or null if the parameters are invalid
+     */
+    public static MouseEvent parseSgr(int finalChar, int[] params, int paramCount) {
+        if (paramCount < 3) {
+            return null;
+        }
+
+        int pb = params[0];
+        int px = params[1];
+        int py = params[2];
+
+        if (px < 1 || py < 1) {
+            return null;
+        }
+
+        boolean sgrRelease = (finalChar == 'm');
+
+        return decodeButton(pb, px, py, sgrRelease);
+    }
+
+    /**
+     * Checks if a CSI dispatch represents an SGR mouse event.
+     *
+     * @param finalChar the CSI final character
+     * @param intermediates the intermediate/private-marker characters
+     * @param intermediateCount the number of intermediates
+     * @return true if this is an SGR mouse event
+     */
+    public static boolean isSgrMouseEvent(int finalChar, int[] intermediates, int intermediateCount) {
+        return intermediateCount > 0
+                && intermediates[0] == '<'
+                && (finalChar == 'M' || finalChar == 'm');
+    }
+
+    // =========================================================================
+    // Button byte decoding (shared across encodings)
+    // =========================================================================
+
+    /**
+     * Decodes the button byte into a MouseEvent.
+     * <p>
+     * The button byte bitfield (after removing +32 offset for legacy):
+     *
+     * <pre>
+     * bits 0-1 (0x03): button index  0=left, 1=middle, 2=right, 3=none/release
+     * bit 2    (0x04): shift modifier
+     * bit 3    (0x08): alt/meta modifier
+     * bit 4    (0x10): ctrl modifier
+     * bit 5    (0x20): motion event flag
+     * bit 6    (0x40): scroll wheel flag
+     * </pre>
+     */
+    private static MouseEvent decodeButton(int pb, int x, int y, boolean sgrRelease) {
+        int buttonIndex = pb & 0x03;
+        boolean shiftMod = (pb & 0x04) != 0;
+        boolean altMod = (pb & 0x08) != 0;
+        boolean ctrlMod = (pb & 0x10) != 0;
+        boolean motion = (pb & 0x20) != 0;
+        boolean scroll = (pb & 0x40) != 0;
+
+        Type type;
+        Button button;
+
+        if (scroll) {
+            type = Type.SCROLL;
+            button = (buttonIndex == 0) ? Button.SCROLL_UP : Button.SCROLL_DOWN;
+        } else if (sgrRelease) {
+            type = Type.RELEASE;
+            button = buttonFromIndex(buttonIndex);
+        } else if (!motion && buttonIndex == 3) {
+            // Legacy/URXVT: release without button identification
+            type = Type.RELEASE;
+            button = Button.NONE;
+        } else if (motion && buttonIndex == 3) {
+            // Hover: motion with no button held
+            type = Type.MOVE;
+            button = Button.NONE;
+        } else if (motion) {
+            type = Type.DRAG;
+            button = buttonFromIndex(buttonIndex);
+        } else {
+            type = Type.PRESS;
+            button = buttonFromIndex(buttonIndex);
+        }
+
+        return new MouseEvent(type, button, x, y, shiftMod, altMod, ctrlMod);
+    }
+
+    private static Button buttonFromIndex(int index) {
+        switch (index) {
+            case 0:
+                return Button.LEFT;
+            case 1:
+                return Button.MIDDLE;
+            case 2:
+                return Button.RIGHT;
+            default:
+                return Button.NONE;
+        }
+    }
+
+    // =========================================================================
+    // Object methods
+    // =========================================================================
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof MouseEvent))
+            return false;
+        MouseEvent that = (MouseEvent) o;
+        return type == that.type && button == that.button
+                && x == that.x && y == that.y
+                && shift == that.shift && alt == that.alt && ctrl == that.ctrl;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type.hashCode();
+        result = 31 * result + button.hashCode();
+        result = 31 * result + x;
+        result = 31 * result + y;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("MouseEvent{");
+        sb.append(type).append(' ').append(button);
+        sb.append(" at (").append(x).append(',').append(y).append(')');
+        if (shift)
+            sb.append(" +Shift");
+        if (alt)
+            sb.append(" +Alt");
+        if (ctrl)
+            sb.append(" +Ctrl");
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/terminal-api/src/main/java/org/aesh/terminal/tty/MouseTracking.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/tty/MouseTracking.java
@@ -1,0 +1,144 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aesh.terminal.tty;
+
+import java.io.IOException;
+
+/**
+ * Controls mouse tracking on the terminal.
+ * <p>
+ * Mouse tracking is enabled by sending DEC private mode sequences to the
+ * terminal. The protocol controls which events are reported, and the
+ * encoding controls how coordinates are transmitted.
+ * <p>
+ * Example usage:
+ *
+ * <pre>
+ * // Enable normal tracking with SGR encoding
+ * MouseTracking.enable(connection, MouseTracking.Protocol.NORMAL);
+ * MouseTracking.enableEncoding(connection, MouseTracking.Encoding.SGR);
+ *
+ * // ... handle mouse events ...
+ *
+ * // Disable on cleanup
+ * MouseTracking.disable(connection, MouseTracking.Protocol.NORMAL);
+ * MouseTracking.disableEncoding(connection, MouseTracking.Encoding.SGR);
+ * </pre>
+ *
+ * @see MouseEvent
+ */
+public final class MouseTracking {
+
+    /**
+     * Mouse tracking protocol — controls which events are reported.
+     */
+    public enum Protocol {
+        /** X10 compatibility mode: button press only. */
+        X10(9),
+        /** Normal tracking: press + release. */
+        NORMAL(1000),
+        /** Button-event tracking: press + release + drag. */
+        BUTTON_MOTION(1002),
+        /** Any-event tracking: press + release + drag + hover. */
+        ANY_MOTION(1003);
+
+        final int mode;
+
+        Protocol(int mode) {
+            this.mode = mode;
+        }
+    }
+
+    /**
+     * Mouse coordinate encoding — controls how coordinates are transmitted.
+     */
+    public enum Encoding {
+        /** SGR encoding: {@code CSI < Pb;Px;Py M/m}. Recommended. No coordinate limits. */
+        SGR(1006),
+        /** UTF-8 encoding. Deprecated. */
+        UTF8(1005),
+        /** URXVT encoding: {@code CSI Pb;Px;Py M}. No release button ID. */
+        URXVT(1015),
+        /** SGR-Pixels encoding: like SGR but with pixel coordinates. */
+        SGR_PIXELS(1016);
+
+        final int mode;
+
+        Encoding(int mode) {
+            this.mode = mode;
+        }
+    }
+
+    /**
+     * Enables a mouse tracking protocol.
+     *
+     * @param out the output to write the escape sequence to
+     * @param protocol the protocol to enable
+     * @throws IOException if writing fails
+     */
+    public static void enable(Appendable out, Protocol protocol) throws IOException {
+        setMode(out, protocol.mode, true);
+    }
+
+    /**
+     * Disables a mouse tracking protocol.
+     *
+     * @param out the output to write the escape sequence to
+     * @param protocol the protocol to disable
+     * @throws IOException if writing fails
+     */
+    public static void disable(Appendable out, Protocol protocol) throws IOException {
+        setMode(out, protocol.mode, false);
+    }
+
+    /**
+     * Enables a mouse coordinate encoding.
+     *
+     * @param out the output to write the escape sequence to
+     * @param encoding the encoding to enable
+     * @throws IOException if writing fails
+     */
+    public static void enableEncoding(Appendable out, Encoding encoding) throws IOException {
+        setMode(out, encoding.mode, true);
+    }
+
+    /**
+     * Disables a mouse coordinate encoding.
+     *
+     * @param out the output to write the escape sequence to
+     * @param encoding the encoding to disable
+     * @throws IOException if writing fails
+     */
+    public static void disableEncoding(Appendable out, Encoding encoding) throws IOException {
+        setMode(out, encoding.mode, false);
+    }
+
+    private static void setMode(Appendable out, int mode, boolean enable) throws IOException {
+        // CSI ? {mode} h (enable) or CSI ? {mode} l (disable)
+        out.append('\033');
+        out.append('[');
+        out.append('?');
+        out.append(Integer.toString(mode));
+        out.append(enable ? 'h' : 'l');
+    }
+
+    private MouseTracking() {
+    }
+}

--- a/terminal-api/src/test/java/org/aesh/terminal/tty/MouseEventTest.java
+++ b/terminal-api/src/test/java/org/aesh/terminal/tty/MouseEventTest.java
@@ -1,0 +1,376 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aesh.terminal.tty;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.aesh.terminal.EventDecoder;
+import org.junit.Test;
+
+/**
+ * Tests for mouse event parsing, protocol control, and EventDecoder integration.
+ */
+public class MouseEventTest {
+
+    // ==================== SGR Parsing ====================
+
+    @Test
+    public void testSgrLeftPress() {
+        // CSI < 0 ; 5 ; 3 M → left press at (5,3)
+        MouseEvent e = MouseEvent.parseSgr('M', new int[] { 0, 5, 3 }, 3);
+        assertNotNull(e);
+        assertEquals(MouseEvent.Type.PRESS, e.type());
+        assertEquals(MouseEvent.Button.LEFT, e.button());
+        assertEquals(5, e.x());
+        assertEquals(3, e.y());
+        assertFalse(e.shift());
+        assertFalse(e.alt());
+        assertFalse(e.ctrl());
+    }
+
+    @Test
+    public void testSgrLeftRelease() {
+        // CSI < 0 ; 5 ; 3 m → left release at (5,3)
+        MouseEvent e = MouseEvent.parseSgr('m', new int[] { 0, 5, 3 }, 3);
+        assertNotNull(e);
+        assertEquals(MouseEvent.Type.RELEASE, e.type());
+        assertEquals(MouseEvent.Button.LEFT, e.button());
+    }
+
+    @Test
+    public void testSgrMiddlePress() {
+        MouseEvent e = MouseEvent.parseSgr('M', new int[] { 1, 10, 20 }, 3);
+        assertEquals(MouseEvent.Button.MIDDLE, e.button());
+        assertEquals(MouseEvent.Type.PRESS, e.type());
+    }
+
+    @Test
+    public void testSgrRightPress() {
+        MouseEvent e = MouseEvent.parseSgr('M', new int[] { 2, 10, 20 }, 3);
+        assertEquals(MouseEvent.Button.RIGHT, e.button());
+    }
+
+    @Test
+    public void testSgrRightRelease() {
+        MouseEvent e = MouseEvent.parseSgr('m', new int[] { 2, 10, 20 }, 3);
+        assertEquals(MouseEvent.Type.RELEASE, e.type());
+        assertEquals(MouseEvent.Button.RIGHT, e.button());
+    }
+
+    @Test
+    public void testSgrScrollUp() {
+        // button byte 64 = scroll wheel (bit 6) + index 0 (scroll up)
+        MouseEvent e = MouseEvent.parseSgr('M', new int[] { 64, 5, 3 }, 3);
+        assertEquals(MouseEvent.Type.SCROLL, e.type());
+        assertEquals(MouseEvent.Button.SCROLL_UP, e.button());
+    }
+
+    @Test
+    public void testSgrScrollDown() {
+        // button byte 65 = scroll wheel (bit 6) + index 1 (scroll down)
+        MouseEvent e = MouseEvent.parseSgr('M', new int[] { 65, 5, 3 }, 3);
+        assertEquals(MouseEvent.Type.SCROLL, e.type());
+        assertEquals(MouseEvent.Button.SCROLL_DOWN, e.button());
+    }
+
+    @Test
+    public void testSgrDrag() {
+        // button byte 32 = motion (bit 5) + index 0 (left)
+        MouseEvent e = MouseEvent.parseSgr('M', new int[] { 32, 5, 3 }, 3);
+        assertEquals(MouseEvent.Type.DRAG, e.type());
+        assertEquals(MouseEvent.Button.LEFT, e.button());
+    }
+
+    @Test
+    public void testSgrMove() {
+        // button byte 35 = motion (bit 5) + index 3 (none) → hover
+        MouseEvent e = MouseEvent.parseSgr('M', new int[] { 35, 5, 3 }, 3);
+        assertEquals(MouseEvent.Type.MOVE, e.type());
+        assertEquals(MouseEvent.Button.NONE, e.button());
+    }
+
+    @Test
+    public void testSgrModifiers() {
+        // button byte 0x1C = shift(4) + alt(8) + ctrl(16) + index 0 (left)
+        MouseEvent e = MouseEvent.parseSgr('M', new int[] { 0x1C, 5, 3 }, 3);
+        assertEquals(MouseEvent.Type.PRESS, e.type());
+        assertTrue(e.shift());
+        assertTrue(e.alt());
+        assertTrue(e.ctrl());
+    }
+
+    @Test
+    public void testSgrShiftOnly() {
+        MouseEvent e = MouseEvent.parseSgr('M', new int[] { 4, 5, 3 }, 3);
+        assertTrue(e.shift());
+        assertFalse(e.alt());
+        assertFalse(e.ctrl());
+    }
+
+    @Test
+    public void testSgrInvalidParams() {
+        assertNull(MouseEvent.parseSgr('M', new int[] { 0, 5 }, 2)); // too few
+        assertNull(MouseEvent.parseSgr('M', new int[] { 0, 0, 3 }, 3)); // x=0 invalid
+        assertNull(MouseEvent.parseSgr('M', new int[] { 0, 5, 0 }, 3)); // y=0 invalid
+    }
+
+    @Test
+    public void testIsSgrMouseEvent() {
+        assertTrue(MouseEvent.isSgrMouseEvent('M', new int[] { '<' }, 1));
+        assertTrue(MouseEvent.isSgrMouseEvent('m', new int[] { '<' }, 1));
+        assertFalse(MouseEvent.isSgrMouseEvent('H', new int[] { '<' }, 1)); // wrong final
+        assertFalse(MouseEvent.isSgrMouseEvent('M', new int[] { '?' }, 1)); // wrong marker
+        assertFalse(MouseEvent.isSgrMouseEvent('M', new int[] {}, 0)); // no marker
+    }
+
+    @Test
+    public void testLargeCoordinates() {
+        // SGR supports coordinates > 223 (no limit unlike legacy)
+        MouseEvent e = MouseEvent.parseSgr('M', new int[] { 0, 500, 300 }, 3);
+        assertEquals(500, e.x());
+        assertEquals(300, e.y());
+    }
+
+    // ==================== MouseEvent Object ====================
+
+    @Test
+    public void testEquals() {
+        MouseEvent a = new MouseEvent(MouseEvent.Type.PRESS, MouseEvent.Button.LEFT,
+                5, 3, false, false, false);
+        MouseEvent b = new MouseEvent(MouseEvent.Type.PRESS, MouseEvent.Button.LEFT,
+                5, 3, false, false, false);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void testNotEquals() {
+        MouseEvent a = new MouseEvent(MouseEvent.Type.PRESS, MouseEvent.Button.LEFT,
+                5, 3, false, false, false);
+        MouseEvent b = new MouseEvent(MouseEvent.Type.RELEASE, MouseEvent.Button.LEFT,
+                5, 3, false, false, false);
+        assertNotEquals(a, b);
+    }
+
+    @Test
+    public void testToString() {
+        MouseEvent e = new MouseEvent(MouseEvent.Type.PRESS, MouseEvent.Button.LEFT,
+                5, 3, true, false, true);
+        String s = e.toString();
+        assertTrue(s.contains("PRESS"));
+        assertTrue(s.contains("LEFT"));
+        assertTrue(s.contains("5"));
+        assertTrue(s.contains("3"));
+        assertTrue(s.contains("Shift"));
+        assertTrue(s.contains("Ctrl"));
+        assertFalse(s.contains("Alt"));
+    }
+
+    // ==================== MouseTracking Sequences ====================
+
+    @Test
+    public void testEnableNormal() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        MouseTracking.enable(sb, MouseTracking.Protocol.NORMAL);
+        assertEquals("\033[?1000h", sb.toString());
+    }
+
+    @Test
+    public void testDisableNormal() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        MouseTracking.disable(sb, MouseTracking.Protocol.NORMAL);
+        assertEquals("\033[?1000l", sb.toString());
+    }
+
+    @Test
+    public void testEnableSgrEncoding() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        MouseTracking.enableEncoding(sb, MouseTracking.Encoding.SGR);
+        assertEquals("\033[?1006h", sb.toString());
+    }
+
+    @Test
+    public void testDisableSgrEncoding() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        MouseTracking.disableEncoding(sb, MouseTracking.Encoding.SGR);
+        assertEquals("\033[?1006l", sb.toString());
+    }
+
+    @Test
+    public void testAllProtocols() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        MouseTracking.enable(sb, MouseTracking.Protocol.X10);
+        assertEquals("\033[?9h", sb.toString());
+
+        sb.setLength(0);
+        MouseTracking.enable(sb, MouseTracking.Protocol.BUTTON_MOTION);
+        assertEquals("\033[?1002h", sb.toString());
+
+        sb.setLength(0);
+        MouseTracking.enable(sb, MouseTracking.Protocol.ANY_MOTION);
+        assertEquals("\033[?1003h", sb.toString());
+    }
+
+    // ==================== EventDecoder Integration ====================
+
+    @Test
+    public void testEventDecoderInterceptsMouse() {
+        List<MouseEvent> mouseEvents = new ArrayList<>();
+        List<int[]> inputEvents = new ArrayList<>();
+
+        EventDecoder decoder = new EventDecoder();
+        decoder.setInputHandler(inputEvents::add);
+        decoder.setMouseHandler(mouseEvents::add);
+
+        // Feed SGR mouse sequence: ESC [ < 0 ; 5 ; 3 M
+        int[] mouseSeq = { 27, 91, 60, 48, 59, 53, 59, 51, 77 };
+        decoder.accept(mouseSeq);
+
+        // Mouse event should be dispatched
+        assertEquals(1, mouseEvents.size());
+        assertEquals(MouseEvent.Type.PRESS, mouseEvents.get(0).type());
+        assertEquals(MouseEvent.Button.LEFT, mouseEvents.get(0).button());
+        assertEquals(5, mouseEvents.get(0).x());
+        assertEquals(3, mouseEvents.get(0).y());
+
+        // No input should leak through
+        assertTrue(inputEvents.isEmpty());
+    }
+
+    @Test
+    public void testEventDecoderTextWithMouse() {
+        List<MouseEvent> mouseEvents = new ArrayList<>();
+        List<int[]> inputEvents = new ArrayList<>();
+
+        EventDecoder decoder = new EventDecoder();
+        decoder.setInputHandler(inputEvents::add);
+        decoder.setMouseHandler(mouseEvents::add);
+
+        // Text + mouse + text: "hi" + ESC[<0;5;3M + "lo"
+        int[] mixed = { 'h', 'i', 27, 91, 60, 48, 59, 53, 59, 51, 77, 'l', 'o' };
+        decoder.accept(mixed);
+
+        // Should get mouse event
+        assertEquals(1, mouseEvents.size());
+        assertEquals(MouseEvent.Type.PRESS, mouseEvents.get(0).type());
+
+        // Should get input (text before and after mouse)
+        assertFalse(inputEvents.isEmpty());
+        // Verify no mouse bytes leaked into input
+        int totalInputChars = 0;
+        for (int[] chunk : inputEvents) {
+            for (int cp : chunk) {
+                assertTrue("Unexpected control char " + cp + " in input",
+                        cp >= 32 || cp == 27); // only printable or ESC
+            }
+            totalInputChars += chunk.length;
+        }
+    }
+
+    @Test
+    public void testEventDecoderNoHandlerPassesThrough() {
+        List<int[]> inputEvents = new ArrayList<>();
+
+        EventDecoder decoder = new EventDecoder();
+        decoder.setInputHandler(inputEvents::add);
+        // No mouse handler — sequences should pass through as input
+
+        int[] mouseSeq = { 27, 91, 60, 48, 59, 53, 59, 51, 77 };
+        decoder.accept(mouseSeq);
+
+        // Input should contain the raw mouse bytes
+        assertFalse(inputEvents.isEmpty());
+    }
+
+    @Test
+    public void testEventDecoderMouseRelease() {
+        List<MouseEvent> mouseEvents = new ArrayList<>();
+
+        EventDecoder decoder = new EventDecoder();
+        decoder.setInputHandler(input -> {
+        });
+        decoder.setMouseHandler(mouseEvents::add);
+
+        // SGR release: ESC [ < 0 ; 5 ; 3 m (lowercase m)
+        int[] releaseSeq = { 27, 91, 60, 48, 59, 53, 59, 51, 109 };
+        decoder.accept(releaseSeq);
+
+        assertEquals(1, mouseEvents.size());
+        assertEquals(MouseEvent.Type.RELEASE, mouseEvents.get(0).type());
+    }
+
+    @Test
+    public void testEventDecoderMultiDigitCoords() {
+        List<MouseEvent> mouseEvents = new ArrayList<>();
+
+        EventDecoder decoder = new EventDecoder();
+        decoder.setInputHandler(input -> {
+        });
+        decoder.setMouseHandler(mouseEvents::add);
+
+        // ESC [ < 0 ; 42 ; 17 M
+        int[] seq = { 27, 91, 60, 48, 59, 52, 50, 59, 49, 55, 77 };
+        decoder.accept(seq);
+
+        assertEquals(1, mouseEvents.size());
+        assertEquals(42, mouseEvents.get(0).x());
+        assertEquals(17, mouseEvents.get(0).y());
+    }
+
+    @Test
+    public void testEventDecoderNonMouseCsiPassesThrough() {
+        List<int[]> inputEvents = new ArrayList<>();
+
+        EventDecoder decoder = new EventDecoder();
+        decoder.setInputHandler(inputEvents::add);
+        decoder.setMouseHandler(event -> {
+        });
+
+        // Arrow up: ESC [ A — not a mouse sequence
+        int[] arrowUp = { 27, 91, 65 };
+        decoder.accept(arrowUp);
+
+        // Should pass through as input, not consumed by mouse handler
+        assertFalse(inputEvents.isEmpty());
+    }
+
+    @Test
+    public void testEventDecoderPartialMouseAcrossChunks() {
+        List<MouseEvent> mouseEvents = new ArrayList<>();
+
+        EventDecoder decoder = new EventDecoder();
+        decoder.setInputHandler(input -> {
+        });
+        decoder.setMouseHandler(mouseEvents::add);
+
+        // Split ESC [ < 0 ; 5 ; 3 M across two chunks
+        decoder.accept(new int[] { 27, 91, 60 });
+        assertEquals(0, mouseEvents.size()); // not complete yet
+
+        decoder.accept(new int[] { 48, 59, 53, 59, 51, 77 });
+        assertEquals(1, mouseEvents.size());
+        assertEquals(5, mouseEvents.get(0).x());
+        assertEquals(3, mouseEvents.get(0).y());
+    }
+}


### PR DESCRIPTION
Add MouseEvent, MouseTracking, and EventDecoder integration for terminal mouse event handling via SGR encoding.

MouseEvent (terminal-api/tty):
- Immutable value type with Type (PRESS, RELEASE, DRAG, MOVE, SCROLL), Button (LEFT, MIDDLE, RIGHT, SCROLL_UP, SCROLL_DOWN, NONE), position (x, y 1-based), and modifiers (shift, alt, ctrl)
- parseSgr() static factory: decodes CSI < Pb;Px;Py M/m format
- isSgrMouseEvent() for detection from VtParser csiDispatch
- Full button byte decoding: index, modifiers, motion, scroll

MouseTracking (terminal-api/tty):
- Protocol enum: X10, NORMAL, BUTTON_MOTION, ANY_MOTION
- Encoding enum: SGR, UTF8, URXVT, SGR_PIXELS
- Static enable/disable/enableEncoding/disableEncoding methods that write DEC private mode sequences (CSI ? N h/l)

EventDecoder integration:
- New mouseHandler field with getter/setter
- filterMouseSgr() state machine intercepts ESC [ < Pb;Px;Py M/m sequences when a mouse handler is registered
- Sequences are parsed into MouseEvent and dispatched to handler
- Non-mouse input passes through unchanged
- Handles partial sequences across accept() chunk boundaries
- Fast path: no ESC in input + idle state = zero allocation

Connection/AbstractConnection:
- New default methods: setMouseHandler(Consumer<MouseEvent>), mouseHandler()
- AbstractConnection delegates to EventDecoder

29 tests covering: all button types, press/release/drag/move/scroll, modifiers, large coordinates, invalid params, protocol sequences, EventDecoder interception (pure mouse, mixed text+mouse, release, multi-digit coords, non-mouse CSI passthrough, partial chunks).

Fixes #161