### PR TITLE
Add Windows mouse event support

### DIFF
--- a/examples/src/main/java/org/aesh/terminal/tty/example/MouseTrackingExample.java
+++ b/examples/src/main/java/org/aesh/terminal/tty/example/MouseTrackingExample.java
@@ -1,0 +1,161 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.aesh.terminal.tty.example;
+
+import java.io.IOException;
+
+import org.aesh.terminal.tty.MouseEvent;
+import org.aesh.terminal.tty.MouseTracking;
+import org.aesh.terminal.tty.Size;
+import org.aesh.terminal.tty.TerminalConnection;
+
+/**
+ * Example demonstrating mouse tracking support.
+ * <p>
+ * Enables SGR mouse tracking and displays mouse events in real-time.
+ * Click anywhere in the terminal to see press/release events.
+ * Move the mouse to see motion events. Use scroll wheel to see
+ * scroll events. Press Ctrl+C to exit.
+ * <p>
+ * Run with:
+ * <pre>
+ * mvn compile -pl examples -am -Pexamples
+ * java -cp examples/target/classes:readline/target/classes:terminal-api/target/classes:terminal-tty/target/classes:terminal-detect/target/classes:readline-api/target/classes \
+ *   org.aesh.readline.example.MouseTrackingExample
+ * </pre>
+ */
+public class MouseTrackingExample {
+
+    public static void main(String... args) throws IOException {
+        TerminalConnection connection = new TerminalConnection();
+
+        // Enter raw mode and enable alternate screen
+        connection.enterRawMode();
+        connection.write("\033[?1049h");  // alternate screen
+        connection.write("\033[2J");       // clear
+        connection.write("\033[?25l");     // hide cursor
+
+        // Enable mouse tracking with ANY_MOTION protocol + SGR encoding
+        MouseTracking.enable(connection, MouseTracking.Protocol.ANY_MOTION);
+        MouseTracking.enableEncoding(connection, MouseTracking.Encoding.SGR);
+
+        // Draw header
+        Size size = connection.size();
+        drawHeader(connection, size);
+        drawFooter(connection, size);
+
+        // Register mouse handler
+        connection.setMouseHandler(event -> {
+            drawEvent(connection, event, size);
+            drawMarker(connection, event);
+        });
+
+        // Handle Ctrl+C to exit
+        connection.setSignalHandler(signal -> {
+            cleanup(connection);
+            System.exit(0);
+        });
+
+        // Handle resize
+        connection.setSizeHandler(newSize -> {
+            connection.write("\033[2J");
+            drawHeader(connection, newSize);
+            drawFooter(connection, newSize);
+        });
+
+        // Block on input
+        connection.openBlocking();
+    }
+
+    private static void drawHeader(TerminalConnection connection, Size size) {
+        connection.write("\033[1;1H");
+        connection.write("\033[1m\033[44m\033[97m");  // bold, blue bg, white
+        StringBuilder header = new StringBuilder(" Mouse Tracking Demo ");
+        while (header.length() < size.getWidth()) {
+            header.append(' ');
+        }
+        connection.write(header.toString());
+        connection.write("\033[0m");
+    }
+
+    private static void drawFooter(TerminalConnection connection, Size size) {
+        connection.write("\033[" + size.getHeight() + ";1H");
+        connection.write("\033[1m\033[44m\033[97m");
+        StringBuilder footer = new StringBuilder(" Press Ctrl+C to exit ");
+        while (footer.length() < size.getWidth()) {
+            footer.append(' ');
+        }
+        connection.write(footer.toString());
+        connection.write("\033[0m");
+    }
+
+    private static void drawEvent(TerminalConnection connection, MouseEvent event, Size size) {
+        // Display event info at row 3
+        connection.write("\033[3;1H\033[K");  // clear line
+        connection.write(String.format(" Event: %-8s  Button: %-10s  Position: (%3d, %3d)",
+                event.type(), event.button(), event.x(), event.y()));
+
+        // Display modifiers at row 4
+        connection.write("\033[4;1H\033[K");
+        StringBuilder mods = new StringBuilder(" Modifiers:");
+        if (event.shift()) mods.append(" Shift");
+        if (event.alt()) mods.append(" Alt");
+        if (event.ctrl()) mods.append(" Ctrl");
+        if (!event.shift() && !event.alt() && !event.ctrl()) mods.append(" (none)");
+        connection.write(mods.toString());
+    }
+
+    private static void drawMarker(TerminalConnection connection, MouseEvent event) {
+        if (event.x() < 1 || event.y() < 1) return;
+
+        // Draw a marker at the mouse position
+        connection.write("\033[" + event.y() + ";" + event.x() + "H");
+        switch (event.type()) {
+            case PRESS:
+                connection.write("\033[91m\033[1m*\033[0m");  // bright red bold
+                break;
+            case RELEASE:
+                connection.write("\033[92m.\033[0m");  // green
+                break;
+            case DRAG:
+                connection.write("\033[93m+\033[0m");  // yellow
+                break;
+            case MOVE:
+                connection.write("\033[90m\u00b7\033[0m");  // gray dot
+                break;
+            case SCROLL:
+                connection.write(event.button() == MouseEvent.Button.SCROLL_UP
+                        ? "\033[96m^\033[0m"   // cyan up
+                        : "\033[96mv\033[0m"); // cyan down
+                break;
+        }
+    }
+
+    private static void cleanup(TerminalConnection connection) {
+        try {
+            MouseTracking.disable(connection, MouseTracking.Protocol.ANY_MOTION);
+            MouseTracking.disableEncoding(connection, MouseTracking.Encoding.SGR);
+            connection.write("\033[?25h");     // show cursor
+            connection.write("\033[?1049l");   // main screen
+        } catch (Exception e) {
+            // ignore on cleanup
+        }
+    }
+}

--- a/terminal-tty/src/main/java/org/aesh/terminal/tty/impl/WinConsoleNative.java
+++ b/terminal-tty/src/main/java/org/aesh/terminal/tty/impl/WinConsoleNative.java
@@ -85,6 +85,8 @@ public final class WinConsoleNative {
 
     /** Event type constants matching Windows INPUT_RECORD.EventType. */
     public static final int KEY_EVENT = 1;
+    /** Mouse event type. */
+    public static final int MOUSE_EVENT = 2;
     /** Window buffer size event type. */
     public static final int WINDOW_BUFFER_SIZE_EVENT = 4;
 
@@ -97,6 +99,7 @@ public final class WinConsoleNative {
      * Read a console input event (key or window resize).
      * Returns int[] where first element is the event type:
      * KEY_EVENT (1): {1, keyDown, repeatCount, vKeyCode, unicodeChar, controlKeyState}
+     * MOUSE_EVENT (2): {2, x, y, buttonState, controlKeyState, eventFlags}
      * WINDOW_BUFFER_SIZE_EVENT (4): {4, width, height}
      * Returns null for other event types or on error.
      *

--- a/terminal-tty/src/main/java/org/aesh/terminal/tty/impl/WinSysTerminal.java
+++ b/terminal-tty/src/main/java/org/aesh/terminal/tty/impl/WinSysTerminal.java
@@ -20,9 +20,11 @@
 package org.aesh.terminal.tty.impl;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 
 import org.aesh.terminal.tty.Capability;
+import org.aesh.terminal.tty.MouseEvent;
 import org.aesh.terminal.tty.Signal;
 import org.aesh.terminal.tty.Size;
 
@@ -40,6 +42,20 @@ public class WinSysTerminal extends AbstractWindowsTerminal {
     private static final int RIGHT_CTRL_PRESSED = 0x0004;
     private static final int LEFT_CTRL_PRESSED = 0x0008;
     private static final int SHIFT_PRESSED = 0x0010;
+
+    // Windows mouse button state constants
+    private static final int FROM_LEFT_1ST_BUTTON_PRESSED = 0x0001;
+    private static final int RIGHTMOST_BUTTON_PRESSED = 0x0002;
+    private static final int FROM_LEFT_2ND_BUTTON_PRESSED = 0x0004;
+
+    // Windows mouse event flags
+    private static final int MOUSE_MOVED = 0x0001;
+    private static final int DOUBLE_CLICK = 0x0002;
+    private static final int MOUSE_WHEELED = 0x0004;
+    private static final int MOUSE_HWHEELED = 0x0008;
+
+    private Consumer<MouseEvent> mouseHandler;
+    private int lastButtonState;
 
     /**
      * Create a new Windows system terminal with the specified name.
@@ -113,6 +129,16 @@ public class WinSysTerminal extends AbstractWindowsTerminal {
             return new byte[0];
         }
 
+        if (event[0] == WinConsoleNative.MOUSE_EVENT) {
+            if (mouseHandler != null) {
+                MouseEvent mouseEvent = translateMouseEvent(event);
+                if (mouseEvent != null) {
+                    mouseHandler.accept(mouseEvent);
+                }
+            }
+            return new byte[0];
+        }
+
         if (event[0] != WinConsoleNative.KEY_EVENT) {
             return new byte[0];
         }
@@ -174,6 +200,36 @@ public class WinSysTerminal extends AbstractWindowsTerminal {
      * as VT escape sequences through KEY_EVENT records instead of as
      * virtual key codes or MOUSE_EVENT records.
      */
+    /**
+     * Set the mouse event handler. Enables/disables ENABLE_MOUSE_INPUT
+     * on the console input handle.
+     */
+    public void setMouseHandler(Consumer<MouseEvent> handler) {
+        this.mouseHandler = handler;
+        if (INPUT_HANDLE == WinConsoleNative.INVALID_HANDLE) {
+            return;
+        }
+        int mode = WinConsoleNative.getConsoleMode(INPUT_HANDLE);
+        if (mode == -1) {
+            return;
+        }
+        if (handler != null) {
+            mode |= ENABLE_MOUSE_INPUT;
+            // Disable quick edit mode — it conflicts with mouse tracking
+            mode &= ~ENABLE_QUICK_EDIT_MODE;
+        } else {
+            mode &= ~ENABLE_MOUSE_INPUT;
+        }
+        WinConsoleNative.setConsoleMode(INPUT_HANDLE, mode);
+    }
+
+    /**
+     * Get the current mouse handler.
+     */
+    public Consumer<MouseEvent> getMouseHandler() {
+        return mouseHandler;
+    }
+
     private void enableVTInput() {
         if (INPUT_HANDLE == WinConsoleNative.INVALID_HANDLE) {
             return;
@@ -207,5 +263,74 @@ public class WinSysTerminal extends AbstractWindowsTerminal {
      */
     public static boolean isVTSupported() {
         return setVTMode();
+    }
+
+    /**
+     * Translate a Windows MOUSE_EVENT_RECORD into a MouseEvent.
+     * Event format: {2, x, y, buttonState, controlKeyState, eventFlags}
+     */
+    private MouseEvent translateMouseEvent(int[] event) {
+        int x = event[1] + 1; // Windows is 0-based, MouseEvent is 1-based
+        int y = event[2] + 1;
+        int buttonState = event[3];
+        int controlKeyState = event[4];
+        int eventFlags = event[5];
+
+        boolean shift = (controlKeyState & SHIFT_PRESSED) != 0;
+        boolean alt = ((controlKeyState & LEFT_ALT_PRESSED) != 0)
+                || ((controlKeyState & RIGHT_ALT_PRESSED) != 0);
+        boolean ctrl = ((controlKeyState & LEFT_CTRL_PRESSED) != 0)
+                || ((controlKeyState & RIGHT_CTRL_PRESSED) != 0);
+
+        MouseEvent.Type type;
+        MouseEvent.Button button;
+
+        if ((eventFlags & MOUSE_WHEELED) != 0) {
+            type = MouseEvent.Type.SCROLL;
+            // High word of buttonState indicates direction
+            button = (buttonState >> 16) > 0
+                    ? MouseEvent.Button.SCROLL_DOWN
+                    : MouseEvent.Button.SCROLL_UP;
+        } else if ((eventFlags & MOUSE_MOVED) != 0) {
+            if (buttonState != 0) {
+                type = MouseEvent.Type.DRAG;
+                button = buttonFromState(buttonState);
+            } else {
+                type = MouseEvent.Type.MOVE;
+                button = MouseEvent.Button.NONE;
+            }
+        } else {
+            // Button press or release — compare with last state to determine
+            int pressed = buttonState & ~lastButtonState;
+            int released = lastButtonState & ~buttonState;
+
+            if (pressed != 0) {
+                type = MouseEvent.Type.PRESS;
+                button = buttonFromState(pressed);
+            } else if (released != 0) {
+                type = MouseEvent.Type.RELEASE;
+                button = buttonFromState(released);
+            } else {
+                // No change — likely a duplicate or focus event
+                lastButtonState = buttonState;
+                return null;
+            }
+        }
+
+        lastButtonState = buttonState;
+        return new MouseEvent(type, button, x, y, shift, alt, ctrl);
+    }
+
+    private static MouseEvent.Button buttonFromState(int state) {
+        if ((state & FROM_LEFT_1ST_BUTTON_PRESSED) != 0) {
+            return MouseEvent.Button.LEFT;
+        }
+        if ((state & RIGHTMOST_BUTTON_PRESSED) != 0) {
+            return MouseEvent.Button.RIGHT;
+        }
+        if ((state & FROM_LEFT_2ND_BUTTON_PRESSED) != 0) {
+            return MouseEvent.Button.MIDDLE;
+        }
+        return MouseEvent.Button.NONE;
     }
 }

--- a/terminal-tty/src/main/java22/org/aesh/terminal/tty/impl/WinConsoleNative.java
+++ b/terminal-tty/src/main/java22/org/aesh/terminal/tty/impl/WinConsoleNative.java
@@ -46,6 +46,7 @@ public final class WinConsoleNative {
 
     /** Event type constants matching Windows INPUT_RECORD.EventType */
     public static final int KEY_EVENT = 1;
+    public static final int MOUSE_EVENT = 2;
     public static final int WINDOW_BUFFER_SIZE_EVENT = 4;
 
     /** Console mode flag: enable virtual terminal processing on output handle */
@@ -83,6 +84,15 @@ public final class WinConsoleNative {
     private static final long IR_CONTROL_KEY_STATE = 16;
     private static final long IR_WBSE_X = 4;
     private static final long IR_WBSE_Y = 6;
+    // MOUSE_EVENT_RECORD union (offset 4):
+    //   4: dwMousePosition.X (SHORT)  6: dwMousePosition.Y (SHORT)
+    //   8: dwButtonState (DWORD)     12: dwControlKeyState (DWORD)
+    //  16: dwEventFlags (DWORD)
+    private static final long IR_MOUSE_X = 4;
+    private static final long IR_MOUSE_Y = 6;
+    private static final long IR_MOUSE_BUTTON_STATE = 8;
+    private static final long IR_MOUSE_CONTROL_KEY_STATE = 12;
+    private static final long IR_MOUSE_EVENT_FLAGS = 16;
 
     private static final MethodHandle GET_STD_HANDLE;
     private static final MethodHandle GET_CONSOLE_MODE;
@@ -208,6 +218,16 @@ public final class WinConsoleNative {
                         record.get(ValueLayout.JAVA_SHORT, IR_VIRTUAL_KEY_CODE) & 0xFFFF,
                         record.get(ValueLayout.JAVA_SHORT, IR_UNICODE_CHAR) & 0xFFFF,
                         record.get(ValueLayout.JAVA_INT, IR_CONTROL_KEY_STATE)
+                };
+            }
+            if (eventType == MOUSE_EVENT) {
+                return new int[] {
+                        MOUSE_EVENT,
+                        record.get(ValueLayout.JAVA_SHORT, IR_MOUSE_X) & 0xFFFF,
+                        record.get(ValueLayout.JAVA_SHORT, IR_MOUSE_Y) & 0xFFFF,
+                        record.get(ValueLayout.JAVA_INT, IR_MOUSE_BUTTON_STATE),
+                        record.get(ValueLayout.JAVA_INT, IR_MOUSE_CONTROL_KEY_STATE),
+                        record.get(ValueLayout.JAVA_INT, IR_MOUSE_EVENT_FLAGS)
                 };
             }
             if (eventType == WINDOW_BUFFER_SIZE_EVENT) {

--- a/terminal-tty/src/main/native/WinConsoleNative.c
+++ b/terminal-tty/src/main/native/WinConsoleNative.c
@@ -187,7 +187,22 @@ JNIEXPORT jintArray JNICALL Java_org_aesh_terminal_tty_impl_WinConsoleNative_rea
         return result;
     }
 
-    /* Other event types (mouse, menu, focus) - ignore */
+    if (record.EventType == MOUSE_EVENT) {
+        MOUSE_EVENT_RECORD *me = &record.Event.MouseEvent;
+        jint fields[6];
+        fields[0] = 2; /* MOUSE_EVENT */
+        fields[1] = (jint)me->dwMousePosition.X;
+        fields[2] = (jint)me->dwMousePosition.Y;
+        fields[3] = (jint)me->dwButtonState;
+        fields[4] = (jint)me->dwControlKeyState;
+        fields[5] = (jint)me->dwEventFlags;
+        jintArray result = (*env)->NewIntArray(env, 6);
+        if (result == NULL) return NULL;
+        (*env)->SetIntArrayRegion(env, result, 0, 6, fields);
+        return result;
+    }
+
+    /* Other event types (menu, focus) - ignore */
     return NULL;
 #else
     return NULL;


### PR DESCRIPTION
Enable mouse tracking on Windows by handling MOUSE_EVENT records from ReadConsoleInputW and managing ENABLE_MOUSE_INPUT console mode.

WinConsoleNative (JNI + FFM):
- Add MOUSE_EVENT constant (2)
- readConsoleInputEvent now returns mouse events as: {2, x, y, buttonState, controlKeyState, eventFlags}
- Previously mouse events were silently dropped (returned null)

WinSysTerminal:
- Add setMouseHandler()/getMouseHandler() for legacy mouse events
- setMouseHandler enables ENABLE_MOUSE_INPUT and disables ENABLE_QUICK_EDIT_MODE (conflicts with mouse tracking)
- translateMouseEvent() converts Windows MOUSE_EVENT_RECORD to MouseEvent: handles press/release (via button state diffing), drag, move, scroll wheel, and modifier keys
- Coordinates converted from 0-based (Windows) to 1-based (MouseEvent convention)

Two mouse input paths on Windows:
1. VT input mode (modern Windows Terminal): mouse events arrive as SGR escape sequences through KEY_EVENT records, handled by EventDecoder's filterMouseSgr() from #161 — no changes needed
2. Legacy mode (older consoles): mouse events arrive as MOUSE_EVENT records, translated to MouseEvent by this code

Fixes #169