### PR TITLE
Improve Windows console mode handling to match miniterm

### DIFF
--- a/terminal-api/src/main/java/org/aesh/terminal/Connection.java
+++ b/terminal-api/src/main/java/org/aesh/terminal/Connection.java
@@ -266,7 +266,9 @@ public interface Connection extends Appendable, AutoCloseable {
     default Attributes enterRawMode() {
         Attributes prvAttr = attributes();
         Attributes newAttr = new Attributes(prvAttr);
-        newAttr.setLocalFlags(EnumSet.of(Attributes.LocalFlag.ICANON, Attributes.LocalFlag.ECHO, Attributes.LocalFlag.IEXTEN),
+        newAttr.setLocalFlags(
+                EnumSet.of(Attributes.LocalFlag.ICANON, Attributes.LocalFlag.ECHO, Attributes.LocalFlag.IEXTEN,
+                        Attributes.LocalFlag.ISIG),
                 false);
         newAttr.setInputFlags(EnumSet.of(Attributes.InputFlag.IXON, Attributes.InputFlag.ICRNL, Attributes.InputFlag.INLCR),
                 false);

--- a/terminal-tty/src/main/java/org/aesh/terminal/tty/impl/AbstractWindowsTerminal.java
+++ b/terminal-tty/src/main/java/org/aesh/terminal/tty/impl/AbstractWindowsTerminal.java
@@ -206,6 +206,9 @@ abstract class AbstractWindowsTerminal extends AbstractTerminal {
         if ((mode & ENABLE_LINE_INPUT) != 0) {
             attributes.setLocalFlag(Attributes.LocalFlag.ICANON, true);
         }
+        if ((mode & ENABLE_PROCESSED_INPUT) != 0) {
+            attributes.setLocalFlag(Attributes.LocalFlag.ISIG, true);
+        }
         return new Attributes(attributes);
     }
 
@@ -223,19 +226,21 @@ abstract class AbstractWindowsTerminal extends AbstractTerminal {
         if (mode == -1) {
             mode = 0;
         }
-        // Clear the flags we manage
-        mode &= ~(ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT | ENABLE_QUICK_EDIT_MODE);
+        // Clear only the flags we manage — preserve everything else
+        // (ENABLE_MOUSE_INPUT, ENABLE_QUICK_EDIT_MODE, ENABLE_EXTENDED_FLAGS, etc.)
+        mode &= ~(ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT);
         // Set them based on Attributes
         if (attr.getLocalFlag(Attributes.LocalFlag.ECHO)) {
             mode |= ENABLE_ECHO_INPUT;
         }
         if (attr.getLocalFlag(Attributes.LocalFlag.ICANON)) {
             mode |= ENABLE_LINE_INPUT;
-            // Quick edit is a line-editing convenience (select text with mouse).
-            // Only enable it in canonical mode; in raw mode it intercepts
-            // SHIFT+mouse which breaks mouse tracking.
-            mode |= ENABLE_QUICK_EDIT_MODE;
         }
+        if (attr.getLocalFlag(Attributes.LocalFlag.ISIG)) {
+            mode |= ENABLE_PROCESSED_INPUT;
+        }
+        // Always enable ENABLE_WINDOW_INPUT for resize events
+        mode |= ENABLE_WINDOW_INPUT;
         if (vtInputEnabled) {
             mode |= ENABLE_VIRTUAL_TERMINAL_INPUT;
         }


### PR DESCRIPTION
enterRawMode() now clears ISIG, which on Windows disables ENABLE_PROCESSED_INPUT via the new ISIG mapping in setAttributes(). This matches miniterm's raw mode formula:
  (saved & ~(LINE | ECHO | PROCESSED)) | WINDOW | VT_INPUT

AbstractWindowsTerminal changes:
- Map ISIG <-> ENABLE_PROCESSED_INPUT in getAttributes/setAttributes
- Stop managing ENABLE_QUICK_EDIT_MODE (preserve original value)
- Always set ENABLE_WINDOW_INPUT for resize event delivery
- Only clear ECHO, LINE_INPUT, PROCESSED_INPUT (flags we model)
- Preserve all other flags (MOUSE_INPUT, QUICK_EDIT, EXTENDED_FLAGS)

On POSIX, clearing ISIG in enterRawMode is a no-op since signal handling was already disabled by setting VINTR=0.

Ref #171